### PR TITLE
Integrate saved address APIs into location flow

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -29,6 +29,7 @@ import PhoneEmailEntry from '~/screens/Auth/AuthWithPhone.tsx/EmailEntry';
 import PhoneNameEntry from '~/screens/Auth/AuthWithPhone.tsx/NameEntry';
 import PhoneAcceptTerms from '~/screens/Auth/AuthWithPhone.tsx/AcceptTerms';
 import { PhoneSignupProvider } from '~/context/PhoneSignupContext';
+import { SelectedAddressProvider } from '~/context/SelectedAddressContext';
 
 const Stack = createNativeStackNavigator();
 
@@ -92,11 +93,13 @@ export default function App() {
         <NavigationContainer>
           <AuthProvider>
             <PhoneSignupProvider>
-          <LocationOverlayProvider>
-                <RootNavigator />
-              </LocationOverlayProvider>
+              <SelectedAddressProvider>
+                <LocationOverlayProvider>
+                  <RootNavigator />
+                </LocationOverlayProvider>
+              </SelectedAddressProvider>
             </PhoneSignupProvider>
-      </AuthProvider>
+          </AuthProvider>
         </NavigationContainer>
       </QueryClientProvider>
     </SafeAreaProvider>

--- a/src/api/addresses.ts
+++ b/src/api/addresses.ts
@@ -1,0 +1,20 @@
+import client from './client';
+import type { SaveAddressRequest, SavedAddressResponse } from '~/interfaces/Address';
+
+export const getMySavedAddresses = async (): Promise<SavedAddressResponse[]> => {
+  const { data } = await client.get<SavedAddressResponse[]>('/addresses/mySavedAddresses');
+  return data;
+};
+
+export const createAddress = async (payload: SaveAddressRequest): Promise<SavedAddressResponse> => {
+  const { data } = await client.post<SavedAddressResponse>('/addresses', payload);
+  return data;
+};
+
+export const updateAddress = async (
+  addressId: string,
+  payload: SaveAddressRequest,
+): Promise<SavedAddressResponse> => {
+  const { data } = await client.put<SavedAddressResponse>(`/addresses/${addressId}`, payload);
+  return data;
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,9 +3,10 @@ import { View, Text, TouchableOpacity } from "react-native";
 import { ArrowLeft, ChevronDown } from "lucide-react-native";
 
 import useLocationOverlay from '~/hooks/useLocationOverlay';
+import useSelectedAddress from '~/hooks/useSelectedAddress';
 
 interface HeaderProps {
-  title: string;
+  title?: string;
   onBack?: () => void;
   onLocationPress?: () => void;
   compact?: boolean;
@@ -18,11 +19,14 @@ export default function Header({
   compact = false,
 }: HeaderProps) {
   const { open } = useLocationOverlay();
+  const { selectedAddress } = useSelectedAddress();
 
   const handleLocationPress = () => {
     open();
     onLocationPress?.();
   };
+
+  const displayTitle = selectedAddress?.formattedAddress ?? title ?? 'Choose delivery address';
 
   return (
     <View className={compact ? "px-3 py-1" : "px-5 py-5"}>
@@ -43,7 +47,7 @@ export default function Header({
             className="truncate text-lg font-semibold text-white"
             numberOfLines={1}
           >
-            {title}
+            {displayTitle}
           </Text>
           <ChevronDown color="white" size={20} />
         </TouchableOpacity>

--- a/src/context/SelectedAddressContext.tsx
+++ b/src/context/SelectedAddressContext.tsx
@@ -1,0 +1,48 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { SavedAddressResponse } from '~/interfaces/Address';
+
+type SelectedAddressContextValue = {
+  selectedAddress: SavedAddressResponse | null;
+  setSelectedAddress: (address: SavedAddressResponse | null) => void;
+  clearSelectedAddress: () => void;
+};
+
+const SelectedAddressContext = createContext<SelectedAddressContextValue | undefined>(undefined);
+
+export const SelectedAddressProvider = ({ children }: { children: ReactNode }) => {
+  const [selectedAddress, updateSelectedAddress] = useState<SavedAddressResponse | null>(null);
+
+  const setSelectedAddress = useCallback((address: SavedAddressResponse | null) => {
+    updateSelectedAddress(address);
+  }, []);
+
+  const clearSelectedAddress = useCallback(() => {
+    updateSelectedAddress(null);
+  }, []);
+
+  const value = useMemo<SelectedAddressContextValue>(
+    () => ({
+      selectedAddress,
+      setSelectedAddress,
+      clearSelectedAddress,
+    }),
+    [selectedAddress, setSelectedAddress, clearSelectedAddress],
+  );
+
+  return <SelectedAddressContext.Provider value={value}>{children}</SelectedAddressContext.Provider>;
+};
+
+export const useSelectedAddressContext = () => {
+  const context = useContext(SelectedAddressContext);
+  if (!context) {
+    throw new Error('useSelectedAddressContext must be used within a SelectedAddressProvider');
+  }
+  return context;
+};

--- a/src/hooks/useSelectedAddress.ts
+++ b/src/hooks/useSelectedAddress.ts
@@ -1,0 +1,5 @@
+import { useSelectedAddressContext } from '~/context/SelectedAddressContext';
+
+const useSelectedAddress = () => useSelectedAddressContext();
+
+export default useSelectedAddress;

--- a/src/interfaces/Address/index.ts
+++ b/src/interfaces/Address/index.ts
@@ -1,0 +1,42 @@
+export type AddressType = 'HOME' | 'APARTMENT' | 'WORK' | 'OTHER';
+
+export interface CoordinatesDto {
+  latitude: number;
+  longitude: number;
+  geohash?: string | null;
+}
+
+export interface SaveAddressRequest {
+  userId?: string | null;
+  type: AddressType;
+  label?: string | null;
+  coordinates: CoordinatesDto;
+  formattedAddress: string;
+  placeId?: string | null;
+  entrancePreference?: string | null;
+  entranceNotes?: string | null;
+  directions?: string | null;
+  notes?: string | null;
+  isPrimary?: boolean | null;
+  typeDetails?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface SavedAddressResponse {
+  id: string;
+  userId: number;
+  type: AddressType;
+  label?: string | null;
+  coordinates: CoordinatesDto;
+  formattedAddress: string;
+  placeId?: string | null;
+  entrancePreference?: string | null;
+  entranceNotes?: string | null;
+  directions?: string | null;
+  notes?: string | null;
+  primary: boolean;
+  typeDetails?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/screens/LocationSelectionScreen.tsx
+++ b/src/screens/LocationSelectionScreen.tsx
@@ -31,6 +31,9 @@ import FoodifyPin from '~/components/icons/FoodifyPin';
 import LocationSearchOverlay, { LocationPrediction } from './LocationSearchOverlay';
 import { NavigationProp, ParamListBase, useNavigation } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { createAddress, getMySavedAddresses, updateAddress } from '~/api/addresses';
+import type { AddressType as AddressTypeApi, SaveAddressRequest, SavedAddressResponse } from '~/interfaces/Address';
+import { getErrorMessage } from '~/helper/apiError';
 
 const mapsApiKey = GOOGLE_MAPS_API_KEY;
 
@@ -55,6 +58,8 @@ const DEFAULT_REGION: Region = {
   longitudeDelta: 0.01,
 };
 
+type AddressKind = 'home' | 'apartment' | 'work' | 'other';
+
 type AddressField = {
   id: string;
   label: string;
@@ -69,7 +74,8 @@ type EntranceOption = {
 };
 
 type AddressTypeConfig = {
-  id: string;
+  id: AddressKind;
+  serverType: AddressTypeApi;
   label: string;
   description: string;
   icon: LucideIcon;
@@ -81,6 +87,7 @@ type AddressTypeConfig = {
 const ADDRESS_TYPES: AddressTypeConfig[] = [
   {
     id: 'home',
+    serverType: 'HOME',
     label: 'Home',
     description: 'House, villa or standalone property',
     icon: Home,
@@ -97,6 +104,7 @@ const ADDRESS_TYPES: AddressTypeConfig[] = [
   },
   {
     id: 'apartment',
+    serverType: 'APARTMENT',
     label: 'Apartment',
     description: 'Multi-unit building or residence',
     icon: Building2,
@@ -114,6 +122,7 @@ const ADDRESS_TYPES: AddressTypeConfig[] = [
   },
   {
     id: 'work',
+    serverType: 'WORK',
     label: 'Work',
     description: 'Office, co-working or store front',
     icon: BriefcaseBusiness,
@@ -131,6 +140,7 @@ const ADDRESS_TYPES: AddressTypeConfig[] = [
   },
   {
     id: 'other',
+    serverType: 'OTHER',
     label: 'Other',
     description: 'Any other type of location',
     icon: Sparkles,
@@ -146,7 +156,7 @@ const ADDRESS_TYPES: AddressTypeConfig[] = [
   },
 ];
 
-type SavedAddress = {
+type SavedAddressListItem = {
   id: string;
   title: string;
   subtitle: string;
@@ -154,56 +164,9 @@ type SavedAddress = {
   icon: LucideIcon;
   accent: string;
   region: Region;
-  typeId: AddressTypeConfig['id'];
+  config: AddressTypeConfig;
+  raw: SavedAddressResponse;
 };
-
-const SAVED_ADDRESSES: SavedAddress[] = [
-  {
-    id: 'home',
-    title: 'Home',
-    subtitle: 'Rue Monji Slim, Ariana',
-    details: 'Apartment 12B, Building Atlas',
-    icon: Home,
-    accent: '#F97316',
-    region: {
-      latitude: 36.8665,
-      longitude: 10.1645,
-      latitudeDelta: 0.01,
-      longitudeDelta: 0.01,
-    },
-    typeId: 'home',
-  },
-  {
-    id: 'work',
-    title: 'Work',
-    subtitle: 'Technopark El Ghazela',
-    details: 'Level 5, Foodify HQ',
-    icon: BriefcaseBusiness,
-    accent: '#0EA5E9',
-    region: {
-      latitude: 36.9009,
-      longitude: 10.1879,
-      latitudeDelta: 0.01,
-      longitudeDelta: 0.01,
-    },
-    typeId: 'work',
-  },
-  {
-    id: 'parents',
-    title: "Parent's place",
-    subtitle: 'La Marsa, Tunis',
-    details: 'Behind Safir Hotel, white gate',
-    icon: Sparkles,
-    accent: '#6366F1',
-    region: {
-      latitude: 36.8913,
-      longitude: 10.3231,
-      latitudeDelta: 0.01,
-      longitudeDelta: 0.01,
-    },
-    typeId: 'other',
-  },
-];
 
 function withOpacity(hex: string, opacity: number): string {
   const sanitized = hex.replace('#', '');
@@ -230,6 +193,7 @@ export default function LocationSelectionScreen({ onClose }: LocationSelectionSc
   const [detailForm, setDetailForm] = useState<Record<string, string>>({});
   const [entranceChoice, setEntranceChoice] = useState<string | null>(null);
   const [selectedSavedId, setSelectedSavedId] = useState<string | null>(null);
+  const [selectedSavedAddress, setSelectedSavedAddress] = useState<SavedAddressResponse | null>(null);
   const [customLabel, setCustomLabel] = useState('');
   const [currentRegion, setCurrentRegion] = useState<Region>(DEFAULT_REGION);
   const [formattedAddress, setFormattedAddress] = useState(initialAddress);
@@ -241,6 +205,12 @@ export default function LocationSelectionScreen({ onClose }: LocationSelectionSc
   const [searchPredictions, setSearchPredictions] = useState<LocationPrediction[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
+  const [savedAddresses, setSavedAddresses] = useState<SavedAddressResponse[]>([]);
+  const [savedAddressesLoading, setSavedAddressesLoading] = useState(false);
+  const [savedAddressesError, setSavedAddressesError] = useState<string | null>(null);
+  const [isSavingAddress, setIsSavingAddress] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [placeId, setPlaceId] = useState<string | null>(null);
 
   const screenHeight = useMemo(() => Dimensions.get('screen').height, []);
   const expandedHeaderHeight = useMemo(() => Math.min(screenHeight * 0.52, vs(460)), [screenHeight]);
@@ -249,6 +219,7 @@ export default function LocationSelectionScreen({ onClose }: LocationSelectionSc
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const initialRegionSettledRef = useRef(false);
   const programmaticChangeRef = useRef(false);
+  const componentMountedRef = useRef(true);
 
   const mapRef = useRef<MapView | null>(null);
   const mapCompactProgress = useSharedValue(0);
@@ -256,6 +227,59 @@ export default function LocationSelectionScreen({ onClose }: LocationSelectionSc
 
   const pinLiftOffset = vs(12);
   const mapCompactOffset = vs(36);
+
+  const savedAddressItems = useMemo(() => {
+    return savedAddresses
+      .map<SavedAddressListItem | null>((address) => {
+        const typeConfig = ADDRESS_TYPES.find((type) => type.serverType === address.type);
+        if (!typeConfig) {
+          return null;
+        }
+
+        const latitudeCandidate = Number(address.coordinates?.latitude);
+        const longitudeCandidate = Number(address.coordinates?.longitude);
+        const region: Region = {
+          latitude: Number.isFinite(latitudeCandidate) ? latitudeCandidate : DEFAULT_REGION.latitude,
+          longitude: Number.isFinite(longitudeCandidate) ? longitudeCandidate : DEFAULT_REGION.longitude,
+          latitudeDelta: 0.01,
+          longitudeDelta: 0.01,
+        };
+
+        const preferredTitle = address.label?.trim().length ? address.label.trim() : typeConfig.label;
+
+        const typeDetailsValue = (() => {
+          const details = address.typeDetails;
+          if (details && typeof details === 'object') {
+            const values = Object.values(details);
+            const firstString = values.find(
+              (value): value is string => typeof value === 'string' && value.trim().length > 0,
+            );
+            return firstString?.trim();
+          }
+          return undefined;
+        })();
+
+        const candidateDetails = [
+          address.directions,
+          address.notes,
+          address.entranceNotes,
+          typeDetailsValue,
+        ].find((value): value is string => typeof value === 'string' && value.trim().length > 0);
+
+        return {
+          id: address.id,
+          title: preferredTitle,
+          subtitle: address.formattedAddress,
+          details: candidateDetails?.trim(),
+          icon: typeConfig.icon,
+          accent: typeConfig.accent,
+          region,
+          config: typeConfig,
+          raw: address,
+        };
+      })
+      .filter((item): item is SavedAddressListItem => Boolean(item));
+  }, [savedAddresses]);
 
   const handleClose = useCallback(() => {
     if (onClose) {
@@ -321,6 +345,38 @@ export default function LocationSelectionScreen({ onClose }: LocationSelectionSc
     };
   }, []);
 
+  useEffect(() => {
+    return () => {
+      componentMountedRef.current = false;
+    };
+  }, []);
+
+  const refreshSavedAddresses = useCallback(async () => {
+    setSavedAddressesLoading(true);
+    setSavedAddressesError(null);
+    try {
+      const addresses = await getMySavedAddresses();
+      if (!componentMountedRef.current) {
+        return;
+      }
+      setSavedAddresses(addresses);
+    } catch (error) {
+      if (!componentMountedRef.current) {
+        return;
+      }
+      setSavedAddressesError(getErrorMessage(error, 'Could not load your saved addresses.'));
+    } finally {
+      if (!componentMountedRef.current) {
+        return;
+      }
+      setSavedAddressesLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshSavedAddresses();
+  }, [refreshSavedAddresses]);
+
   const handleRegionChange = useCallback(() => {
     if (!initialRegionSettledRef.current) {
       return;
@@ -334,10 +390,13 @@ export default function LocationSelectionScreen({ onClose }: LocationSelectionSc
     setHasConfirmedPoint(false);
     setScreenState('compose');
     setSelectedSavedId(null);
+    setSelectedSavedAddress(null);
     setActiveType(null);
     setEntranceChoice(null);
     setGeocodeError(null);
     setIsGeocoding(true);
+    setPlaceId(null);
+    setSaveError(null);
   }, [pinLiftOffset, pinOffset, setScreenState]);
 
   const handleRegionChangeComplete = useCallback(
@@ -361,10 +420,12 @@ export default function LocationSelectionScreen({ onClose }: LocationSelectionSc
     setHasConfirmedPoint(true);
     setScreenState('details');
     setSelectedSavedId(null);
+    setSelectedSavedAddress(null);
     setActiveType((current) => current ?? ADDRESS_TYPES[0]);
     setDetailForm({});
     setEntranceChoice(null);
     setCustomLabel('');
+    setSaveError(null);
   }, [isGeocoding]);
 
   const recenterToDefault = useCallback(() => {
@@ -374,8 +435,13 @@ export default function LocationSelectionScreen({ onClose }: LocationSelectionSc
     setHasConfirmedPoint(false);
     setScreenState('compose');
     setSelectedSavedId(null);
+    setSelectedSavedAddress(null);
     setActiveType(null);
     setEntranceChoice(null);
+    setDetailForm({});
+    setCustomLabel('');
+    setPlaceId(null);
+    setSaveError(null);
     fetchAddress(DEFAULT_REGION);
   }, [fetchAddress]);
 
@@ -394,6 +460,7 @@ export default function LocationSelectionScreen({ onClose }: LocationSelectionSc
     if (type.id !== 'other') {
       setCustomLabel('');
     }
+    setSaveError(null);
   }, []);
 
   const handleDetailChange = useCallback((fieldId: string, value: string) => {
@@ -407,40 +474,166 @@ export default function LocationSelectionScreen({ onClose }: LocationSelectionSc
     setEntranceChoice((current) => (current === optionId ? null : optionId));
   }, []);
 
-  const handleSelectSavedAddress = useCallback(
-    (address: SavedAddress) => {
-      programmaticChangeRef.current = true;
-      setScreenState('list');
-      setSelectedSavedId(address.id);
-      setHasConfirmedPoint(false);
-      setEntranceChoice(null);
-      const typeForAddress = ADDRESS_TYPES.find((type) => type.id === address.typeId) ?? null;
-      setActiveType(typeForAddress);
-      if (typeForAddress?.id === 'other') {
-        setCustomLabel(address.title);
-      } else {
-        setCustomLabel('');
-      }
-      setDetailForm({});
-      setFormattedAddress(address.subtitle);
-      setCurrentRegion(address.region);
-      setGeocodeError(null);
-      setIsGeocoding(true);
-      mapRef.current?.animateToRegion(address.region, 320);
-      fetchAddress(address.region);
-    },
-    [fetchAddress]
-  );
+  const handleSelectSavedAddress = useCallback((item: SavedAddressListItem) => {
+    programmaticChangeRef.current = true;
+    setScreenState('details');
+    setSelectedSavedId(item.id);
+    setSelectedSavedAddress(item.raw);
+    setHasConfirmedPoint(true);
+    setActiveType(item.config);
 
-  const handleSaveAddress = useCallback(() => {
-    setScreenState('list');
-    setHasConfirmedPoint(false);
-    setSelectedSavedId(null);
-    setActiveType(null);
-    setEntranceChoice(null);
-    setDetailForm({});
-    setCustomLabel('');
+    const nextDetailForm: Record<string, string> = {};
+    const detailsSource = item.raw.typeDetails;
+    item.config.detailFields.forEach((field) => {
+      if (detailsSource && typeof detailsSource === 'object' && field.id in detailsSource) {
+        const value = (detailsSource as Record<string, unknown>)[field.id];
+        nextDetailForm[field.id] = value !== undefined && value !== null ? String(value) : '';
+      } else {
+        nextDetailForm[field.id] = '';
+      }
+    });
+    setDetailForm(nextDetailForm);
+    setEntranceChoice(item.raw.entrancePreference ?? null);
+    if (item.config.id === 'other') {
+      setCustomLabel(item.raw.label ?? '');
+    } else {
+      setCustomLabel('');
+    }
+    setFormattedAddress(item.raw.formattedAddress);
+    setCurrentRegion(item.region);
+    setGeocodeError(null);
+    setIsGeocoding(false);
+    setPlaceId(item.raw.placeId ?? null);
+    setSaveError(null);
+    mapRef.current?.animateToRegion(item.region, 320);
   }, []);
+
+  const handleSaveAddress = useCallback(async () => {
+    if (!SelectedType) {
+      return;
+    }
+
+    setIsSavingAddress(true);
+    setSaveError(null);
+
+    const sanitizedDetails: Record<string, string> = {};
+    Object.entries(detailForm).forEach(([key, value]) => {
+      if (typeof value !== 'string') {
+        return;
+      }
+      const trimmed = value.trim();
+      if (trimmed.length > 0) {
+        sanitizedDetails[key] = trimmed;
+      }
+    });
+
+    const resolvedLabel = (() => {
+      const existingLabel = selectedSavedAddress?.label?.trim();
+      if (SelectedType.id === 'other') {
+        const custom = customLabel.trim();
+        if (custom.length > 0) {
+          return custom;
+        }
+        if (existingLabel && existingLabel.length > 0) {
+          return existingLabel;
+        }
+        return SelectedType.label;
+      }
+      if (existingLabel && existingLabel.length > 0) {
+        return existingLabel;
+      }
+      return SelectedType.label;
+    })();
+
+    const typeDetails: Record<string, string> = { ...sanitizedDetails };
+
+    const requestPayload: SaveAddressRequest = {
+      type: SelectedType.serverType,
+      label: resolvedLabel?.trim().length ? resolvedLabel.trim() : undefined,
+      coordinates: {
+        latitude: currentRegion.latitude,
+        longitude: currentRegion.longitude,
+      },
+      formattedAddress,
+      placeId: placeId ?? undefined,
+      entrancePreference: entranceChoice ?? undefined,
+      entranceNotes: selectedSavedAddress?.entranceNotes ?? undefined,
+      directions: typeDetails.directions ?? undefined,
+      notes: typeDetails.notes ?? undefined,
+      isPrimary: selectedSavedAddress ? selectedSavedAddress.primary : savedAddresses.length === 0 ? true : undefined,
+    };
+
+    if (typeDetails.directions) {
+      delete typeDetails.directions;
+    }
+    if (typeDetails.notes) {
+      delete typeDetails.notes;
+    }
+    if (SelectedType.id === 'other' && typeDetails.label) {
+      delete typeDetails.label;
+    }
+
+    if (Object.keys(typeDetails).length > 0) {
+      requestPayload.typeDetails = typeDetails;
+    }
+
+    try {
+      let response: SavedAddressResponse;
+      if (selectedSavedAddress) {
+        response = await updateAddress(selectedSavedAddress.id, requestPayload);
+      } else {
+        response = await createAddress(requestPayload);
+      }
+
+      setSavedAddresses((previous) => {
+        const exists = previous.some((address) => address.id === response.id);
+        if (exists) {
+          return previous.map((address) => (address.id === response.id ? response : address));
+        }
+        return [response, ...previous];
+      });
+
+      const latitudeCandidate = Number(response.coordinates?.latitude);
+      const longitudeCandidate = Number(response.coordinates?.longitude);
+      const nextRegion: Region = {
+        latitude: Number.isFinite(latitudeCandidate) ? latitudeCandidate : DEFAULT_REGION.latitude,
+        longitude: Number.isFinite(longitudeCandidate) ? longitudeCandidate : DEFAULT_REGION.longitude,
+        latitudeDelta: 0.01,
+        longitudeDelta: 0.01,
+      };
+
+      setSelectedSavedId(response.id);
+      setSelectedSavedAddress(null);
+      setHasConfirmedPoint(false);
+      setScreenState('list');
+      setActiveType(null);
+      setEntranceChoice(null);
+      setDetailForm({});
+      setCustomLabel('');
+      setPlaceId(null);
+      setSaveError(null);
+      setGeocodeError(null);
+      setIsGeocoding(false);
+      setCurrentRegion(nextRegion);
+      setFormattedAddress(response.formattedAddress);
+      mapRef.current?.animateToRegion(nextRegion, 320);
+    } catch (error) {
+      setSaveError(getErrorMessage(error, 'Could not save this address. Please try again.'));
+    } finally {
+      setIsSavingAddress(false);
+    }
+  }, [
+    SelectedType,
+    customLabel,
+    currentRegion.latitude,
+    currentRegion.longitude,
+    detailForm,
+    entranceChoice,
+    formattedAddress,
+    placeId,
+    savedAddresses.length,
+    selectedSavedAddress,
+  ]);
 
   const mapAnimatedStyle = useAnimatedStyle(() => {
     const compactProgress = mapCompactProgress.value;
@@ -465,10 +658,13 @@ export default function LocationSelectionScreen({ onClose }: LocationSelectionSc
   const openSearch = useCallback(() => {
     setScreenState('compose');
     setSelectedSavedId(null);
+    setSelectedSavedAddress(null);
     setSearchActive(true);
     setSearchQuery('');
     setSearchPredictions([]);
     setSearchError(null);
+    setPlaceId(null);
+    setSaveError(null);
   }, []);
 
   const closeSearch = useCallback(() => {
@@ -574,12 +770,15 @@ export default function LocationSelectionScreen({ onClose }: LocationSelectionSc
           setHasConfirmedPoint(false);
           setScreenState('compose');
           setSelectedSavedId(null);
+          setSelectedSavedAddress(null);
           setActiveType(null);
           setEntranceChoice(null);
           setDetailForm({});
           programmaticChangeRef.current = true;
           setFormattedAddress(data.result.formatted_address ?? prediction.primaryText);
           setGeocodeError(null);
+          setPlaceId(prediction.placeId);
+          setSaveError(null);
           mapRef.current?.animateToRegion(nextRegion, 320);
           fetchAddress(nextRegion);
           closeSearch();
@@ -712,42 +911,58 @@ export default function LocationSelectionScreen({ onClose }: LocationSelectionSc
                     Choose a frequent spot or add a brand new location.
                   </Text>
 
-                  {SAVED_ADDRESSES.map((address) => {
-                    const Icon = address.icon;
-                    const isActive = selectedSavedId === address.id;
-                    return (
-                      <TouchableOpacity
-                        key={address.id}
-                        activeOpacity={0.85}
-                        onPress={() => handleSelectSavedAddress(address)}
-                        style={[
-                          styles.savedAddressRow,
-                          isActive && {
-                            borderColor: withOpacity(address.accent, 0.5),
-                            backgroundColor: withOpacity(address.accent, 0.14),
-                          },
-                        ]}
-                      >
-                        <View style={[styles.savedIconBadge, { backgroundColor: withOpacity(address.accent, 0.22) }]}>
-                          <Icon size={s(20)} color={address.accent} />
-                        </View>
-                        <View style={styles.savedCopy}>
-                          <Text allowFontScaling={false} style={styles.savedRowTitle}>
-                            {address.title}
-                          </Text>
-                          <Text allowFontScaling={false} style={styles.savedRowSubtitle} numberOfLines={1}>
-                            {address.subtitle}
-                          </Text>
-                          {address.details ? (
-                            <Text allowFontScaling={false} style={styles.savedRowDetails} numberOfLines={1}>
-                              {address.details}
+                  {savedAddressesLoading ? (
+                    <View style={styles.savedLoadingContainer}>
+                      <ActivityIndicator size="small" color={palette.accent} />
+                    </View>
+                  ) : savedAddressItems.length > 0 ? (
+                    savedAddressItems.map((address) => {
+                      const Icon = address.icon;
+                      const isActive = selectedSavedId === address.id;
+                      return (
+                        <TouchableOpacity
+                          key={address.id}
+                          activeOpacity={0.85}
+                          onPress={() => handleSelectSavedAddress(address)}
+                          style={[
+                            styles.savedAddressRow,
+                            isActive && {
+                              borderColor: withOpacity(address.accent, 0.5),
+                              backgroundColor: withOpacity(address.accent, 0.14),
+                            },
+                          ]}
+                        >
+                          <View style={[styles.savedIconBadge, { backgroundColor: withOpacity(address.accent, 0.22) }]}>
+                            <Icon size={s(20)} color={address.accent} />
+                          </View>
+                          <View style={styles.savedCopy}>
+                            <Text allowFontScaling={false} style={styles.savedRowTitle}>
+                              {address.title}
                             </Text>
-                          ) : null}
-                        </View>
-                        <ChevronRight size={s(18)} color={palette.textSecondary} />
-                      </TouchableOpacity>
-                    );
-                  })}
+                            <Text allowFontScaling={false} style={styles.savedRowSubtitle} numberOfLines={1}>
+                              {address.subtitle}
+                            </Text>
+                            {address.details ? (
+                              <Text allowFontScaling={false} style={styles.savedRowDetails} numberOfLines={1}>
+                                {address.details}
+                              </Text>
+                            ) : null}
+                          </View>
+                          <ChevronRight size={s(18)} color={palette.textSecondary} />
+                        </TouchableOpacity>
+                      );
+                    })
+                  ) : (
+                    <Text allowFontScaling={false} style={styles.savedEmptyState}>
+                      You have no saved addresses yet. Pin a spot to add one.
+                    </Text>
+                  )}
+
+                  {savedAddressesError ? (
+                    <Text allowFontScaling={false} style={styles.savedErrorText}>
+                      {savedAddressesError}
+                    </Text>
+                  ) : null}
 
                   <TouchableOpacity activeOpacity={0.9} style={styles.addAddressButton} onPress={openSearch}>
                     <Text allowFontScaling={false} style={styles.addAddressLabel}>
@@ -877,11 +1092,25 @@ export default function LocationSelectionScreen({ onClose }: LocationSelectionSc
                     </View>
                   </View>
 
-                  <TouchableOpacity activeOpacity={0.9} style={styles.primaryButton} onPress={handleSaveAddress}>
-                    <Text allowFontScaling={false} style={styles.primaryButtonText}>
-                      Save and continue
-                    </Text>
+                  <TouchableOpacity
+                    activeOpacity={0.9}
+                    style={[styles.primaryButton, (isSavingAddress || !SelectedType) && styles.primaryButtonDisabled]}
+                    onPress={handleSaveAddress}
+                    disabled={isSavingAddress || !SelectedType}
+                  >
+                    {isSavingAddress ? (
+                      <ActivityIndicator size="small" color={palette.surfaceAlt} />
+                    ) : (
+                      <Text allowFontScaling={false} style={styles.primaryButtonText}>
+                        Save and continue
+                      </Text>
+                    )}
                   </TouchableOpacity>
+                  {saveError ? (
+                    <Text allowFontScaling={false} style={styles.saveErrorText}>
+                      {saveError}
+                    </Text>
+                  ) : null}
                   <TouchableOpacity
                     activeOpacity={0.9}
                     style={styles.secondaryButton}
@@ -1196,6 +1425,22 @@ const styles = ScaledSheet.create({
     fontSize: '12@ms',
     marginTop: '2@vs',
   },
+  savedLoadingContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: '16@vs',
+  },
+  savedEmptyState: {
+    color: palette.textSecondary,
+    fontSize: '13@ms',
+    marginBottom: '16@vs',
+  },
+  savedErrorText: {
+    color: palette.accent,
+    fontSize: '12.5@ms',
+    marginTop: '4@vs',
+    marginBottom: '12@vs',
+  },
   addAddressButton: {
     marginTop: '8@vs',
     paddingVertical: '14@vs',
@@ -1312,11 +1557,20 @@ const styles = ScaledSheet.create({
     alignItems: 'center',
     backgroundColor: palette.accent,
   },
+  primaryButtonDisabled: {
+    opacity: 0.72,
+  },
   primaryButtonText: {
     color: '#FFFFFF',
     fontSize: '15@ms',
     fontWeight: '700',
     letterSpacing: 0.4,
+  },
+  saveErrorText: {
+    color: palette.accent,
+    fontSize: '12.5@ms',
+    marginTop: '10@vs',
+    textAlign: 'center',
   },
   secondaryButton: {
     marginTop: '14@vs',

--- a/src/screens/LocationSelectionScreen.tsx
+++ b/src/screens/LocationSelectionScreen.tsx
@@ -957,21 +957,28 @@ export default function LocationSelectionScreen({ onClose }: LocationSelectionSc
                             pressed && styles.savedRowPressed,
                           ]}
                         >
-                          <View style={[styles.savedIconBadge, { backgroundColor: withOpacity(address.accent, 0.22) }]}>
-                            <Icon size={s(20)} color={address.accent} />
-                          </View>
-                          <View style={styles.savedCopy}>
-                            <Text allowFontScaling={false} style={styles.savedRowTitle}>
-                              {address.title}
-                            </Text>
-                            <Text allowFontScaling={false} style={styles.savedRowSubtitle} numberOfLines={1}>
-                              {address.subtitle}
-                            </Text>
-                            {address.details ? (
-                              <Text allowFontScaling={false} style={styles.savedRowDetails} numberOfLines={1}>
-                                {address.details}
+                          <View style={styles.savedRowInfo}>
+                            <View
+                              style={[
+                                styles.savedIconBadge,
+                                { backgroundColor: withOpacity(address.accent, 0.22) },
+                              ]}
+                            >
+                              <Icon size={s(20)} color={address.accent} />
+                            </View>
+                            <View style={styles.savedCopy}>
+                              <Text allowFontScaling={false} style={styles.savedRowTitle}>
+                                {address.title}
                               </Text>
-                            ) : null}
+                              <Text allowFontScaling={false} style={styles.savedRowSubtitle} numberOfLines={1}>
+                                {address.subtitle}
+                              </Text>
+                              {address.details ? (
+                                <Text allowFontScaling={false} style={styles.savedRowDetails} numberOfLines={1}>
+                                  {address.details}
+                                </Text>
+                              ) : null}
+                            </View>
                           </View>
                           <View style={styles.savedRowActions}>
                             {isActive ? (
@@ -1448,7 +1455,7 @@ const styles = ScaledSheet.create({
   },
   savedAddressRow: {
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'stretch',
     borderRadius: '18@ms',
     borderWidth: '1@s',
     borderColor: palette.divider,
@@ -1456,6 +1463,12 @@ const styles = ScaledSheet.create({
     paddingVertical: '14@vs',
     marginBottom: '12@vs',
     backgroundColor: palette.surface,
+  },
+  savedRowInfo: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginRight: '12@s',
   },
   savedRowPressed: {
     opacity: 0.92,
@@ -1470,6 +1483,7 @@ const styles = ScaledSheet.create({
   },
   savedCopy: {
     flex: 1,
+    justifyContent: 'center',
   },
   savedRowTitle: {
     color: palette.textPrimary,
@@ -1489,6 +1503,8 @@ const styles = ScaledSheet.create({
   savedRowActions: {
     flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'flex-end',
+    alignSelf: 'stretch',
     marginLeft: '12@s',
   },
   selectedBadge: {


### PR DESCRIPTION
## Summary
- add address API client helpers and TypeScript interfaces for saved addresses
- load, render, and persist saved addresses in LocationSelectionScreen using the new backend endpoints
- surface loading, error, and saving states for a smoother location workflow

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_b_68de9276efc8832caaab0de2bd139a06