### PR TITLE
Add checkout order screen with payment modal

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,6 +12,7 @@ import useAuth from '~/hooks/useAuth';
 import LocationSelectionScreen from '~/screens/LocationSelectionScreen';
 import EmailLogin from '~/screens/Auth/AuthWithEmail.tsx/EmailLogin';
 import CheckoutOrder from '~/screens/CheckoutOrder';
+import CouponCode from '~/screens/CouponCode';
 import OrderHistoryScreen from '~/screens/Profile/OrderHistoryScreen';
 import AccountScreen from '~/screens/Profile/AccountScreen';
 import ProfileScreen from '~/screens/Profile/ProfileScreen';
@@ -60,6 +61,7 @@ const RootNavigator = () => {
           <Stack.Screen name="Search" component={SearchScreen} />
           <Stack.Screen name="Cart" component={Cart} />
           <Stack.Screen name="CheckoutOrder" component={CheckoutOrder} />
+          <Stack.Screen name="CouponCode" component={CouponCode} />
           <Stack.Screen name="Profile" component={ProfileScreen} />
           <Stack.Screen name="OrderHistory" component={OrderHistoryScreen} />
           <Stack.Screen name="AccountSettings" component={AccountScreen} />

--- a/App.tsx
+++ b/App.tsx
@@ -11,6 +11,7 @@ import AuthScreen from '~/screens/Auth/AuthScreen';
 import useAuth from '~/hooks/useAuth';
 import LocationSelectionScreen from '~/screens/LocationSelectionScreen';
 import EmailLogin from '~/screens/Auth/AuthWithEmail.tsx/EmailLogin';
+import CheckoutOrder from '~/screens/CheckoutOrder';
 import OrderHistoryScreen from '~/screens/Profile/OrderHistoryScreen';
 import AccountScreen from '~/screens/Profile/AccountScreen';
 import ProfileScreen from '~/screens/Profile/ProfileScreen';
@@ -58,6 +59,7 @@ const RootNavigator = () => {
           <Stack.Screen name="Home" component={Home} />
           <Stack.Screen name="Search" component={SearchScreen} />
           <Stack.Screen name="Cart" component={Cart} />
+          <Stack.Screen name="CheckoutOrder" component={CheckoutOrder} />
           <Stack.Screen name="Profile" component={ProfileScreen} />
           <Stack.Screen name="OrderHistory" component={OrderHistoryScreen} />
           <Stack.Screen name="AccountSettings" component={AccountScreen} />

--- a/src/components/FixedOrderBar.tsx
+++ b/src/components/FixedOrderBar.tsx
@@ -5,16 +5,17 @@ export interface FixedOrderBarProps {
     total: string;
     onSeeCart: () => void;
     style?: StyleProp<ViewStyle>;
+    buttonLabel?: string;
 }
 
-const FixedOrderBar: React.FC<FixedOrderBarProps> = ({ total, onSeeCart, style }) => (
+const FixedOrderBar: React.FC<FixedOrderBarProps> = ({ total, onSeeCart, style, buttonLabel = "See my Cart" }) => (
     <View className="absolute left-0 right-0 bg-white px-4 py-3 flex-row justify-between shadow-lg  overflow-hidden items-center z-50" style={style}>
         <Text allowFontScaling={false} className="text-[#CA251B] text-base font-bold">Order : {total}</Text>
         <TouchableOpacity 
             onPress={onSeeCart}
             className="bg-[#CA251B] rounded-lg px-8 py-2"
         >
-            <Text allowFontScaling={false} className="text-white text-base font-['roboto']">See my Cart</Text>
+            <Text allowFontScaling={false} className="text-white text-base font-['roboto']">{buttonLabel}</Text>
         </TouchableOpacity>
     </View>
 );

--- a/src/screens/Cart.tsx
+++ b/src/screens/Cart.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { Trash2, Minus, Plus, ChevronDown, ArrowLeft } from 'lucide-react-native';
-import { View, Text, TouchableOpacity, Dimensions } from 'react-native';
+import { Trash2, Minus, Plus } from 'lucide-react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
 import { useNavigation, NavigationProp, ParamListBase } from '@react-navigation/native';
 import MainLayout from '~/layouts/MainLayout';
 import { Image } from 'expo-image';
@@ -9,7 +9,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { vs } from 'react-native-size-matters';
 import Header from '~/components/Header';
 
-const { width } = Dimensions.get('window');
 const primaryColor = '#CA251B';
 
 interface CartItem {
@@ -199,7 +198,8 @@ export default function Cart() {
       />
       <FixedOrderBar
         total={totalOrderPrice}
-        onSeeCart={() => null}
+        onSeeCart={() => navigation.navigate('CheckoutOrder')}
+        buttonLabel="Checkout"
         style={{ bottom: 60 + insets.bottom }}
       />
     </View>

--- a/src/screens/CheckoutOrder.tsx
+++ b/src/screens/CheckoutOrder.tsx
@@ -1,0 +1,323 @@
+import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  ScrollView,
+  TextInput,
+  StyleSheet,
+  Modal,
+} from 'react-native';
+import { useNavigation, NavigationProp, ParamListBase } from '@react-navigation/native';
+import { ArrowLeft, ChevronDown, CreditCard, TicketPercent, MapPin, PenSquare, Wallet } from 'lucide-react-native';
+import MapView, { Marker } from 'react-native-maps';
+
+const sectionTitleColor = '#17213A';
+const accentColor = '#CA251B';
+const borderColor = '#E8E9EC';
+
+interface AccordionProps {
+  title: string;
+  expanded: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}
+
+const Accordion: React.FC<AccordionProps> = ({ title, expanded, onToggle, children }) => (
+  <View className="mt-4 overflow-hidden rounded-3xl border bg-white" style={{ borderColor }}>
+    <TouchableOpacity
+      activeOpacity={0.8}
+      onPress={onToggle}
+      className="flex-row items-center justify-between px-5 py-4"
+    >
+      <Text allowFontScaling={false} className="text-base font-semibold" style={{ color: sectionTitleColor }}>
+        {title}
+      </Text>
+      <ChevronDown
+        size={20}
+        color={sectionTitleColor}
+        style={{ transform: [{ rotate: expanded ? '180deg' : '0deg' }] }}
+      />
+    </TouchableOpacity>
+    {expanded && (
+      <View className="border-t px-5 pb-5 pt-4" style={{ borderColor }}>
+        {children}
+      </View>
+    )}
+  </View>
+);
+
+const PaymentModal: React.FC<{
+  visible: boolean;
+  onClose: () => void;
+  onSelect: (method: string) => void;
+  selected: string;
+}> = ({ visible, onClose, onSelect, selected }) => (
+  <Modal
+    animationType="fade"
+    transparent
+    visible={visible}
+    onRequestClose={onClose}
+  >
+    <View className="flex-1 justify-center bg-[#17213A]/40 px-6">
+      <TouchableOpacity
+        activeOpacity={1}
+        onPress={onClose}
+        className="absolute inset-0"
+      />
+      <View className="rounded-3xl bg-white p-6 shadow-lg">
+        <Text allowFontScaling={false} className="text-center text-lg font-semibold" style={{ color: sectionTitleColor }}>
+          Payment method
+        </Text>
+        <TouchableOpacity
+          activeOpacity={0.8}
+          onPress={() => onSelect('Add new Credit Card')}
+          className="mt-6 flex-row items-center justify-between rounded-2xl border px-4 py-4"
+          style={{
+            borderColor: selected === 'Add new Credit Card' ? accentColor : '#EFEFF1',
+            backgroundColor: selected === 'Add new Credit Card' ? '#FFF5F4' : 'white',
+          }}
+        >
+          <View className="flex-row items-center">
+            <CreditCard size={22} color={accentColor} />
+            <Text allowFontScaling={false} className="ml-3 text-base font-semibold" style={{ color: sectionTitleColor }}>
+              Add new Credit Card
+            </Text>
+          </View>
+          <ChevronDown size={20} color={sectionTitleColor} style={{ transform: [{ rotate: '-90deg' }] }} />
+        </TouchableOpacity>
+        <TouchableOpacity
+          activeOpacity={0.8}
+          onPress={() => onSelect('Pay by Cash')}
+          className="mt-4 flex-row items-center justify-between rounded-2xl border px-4 py-4"
+          style={{
+            borderColor: selected === 'Pay by Cash' ? accentColor : '#EFEFF1',
+            backgroundColor: selected === 'Pay by Cash' ? '#FFF5F4' : 'white',
+          }}
+        >
+          <View className="flex-row items-center">
+            <Wallet size={22} color={accentColor} />
+            <Text allowFontScaling={false} className="ml-3 text-base font-semibold" style={{ color: sectionTitleColor }}>
+              Pay by Cash
+            </Text>
+          </View>
+          <View
+            className="h-5 w-5 items-center justify-center rounded-full border"
+            style={{ borderColor: accentColor, backgroundColor: 'white' }}
+          >
+            {selected === 'Pay by Cash' && (
+              <View className="h-3.5 w-3.5 rounded-full" style={{ backgroundColor: accentColor }} />
+            )}
+          </View>
+        </TouchableOpacity>
+      </View>
+    </View>
+  </Modal>
+);
+
+const CheckoutOrder: React.FC = () => {
+  const navigation = useNavigation<NavigationProp<ParamListBase>>();
+  const [allergiesExpanded, setAllergiesExpanded] = useState(false);
+  const [commentExpanded, setCommentExpanded] = useState(false);
+  const [allergies, setAllergies] = useState('');
+  const [comment, setComment] = useState('');
+  const [paymentMethod, setPaymentMethod] = useState('Select Payment method');
+  const [isPaymentModalVisible, setIsPaymentModalVisible] = useState(false);
+
+  const totalProducts = 4;
+  const restaurantName = 'Di Napoli';
+
+  const handlePaymentSelection = (method: string) => {
+    setPaymentMethod(method);
+    setIsPaymentModalVisible(false);
+  };
+
+  return (
+    <SafeAreaView className="flex-1 bg-white">
+      <View className="flex-row items-center px-4 pb-4 pt-2">
+        <TouchableOpacity onPress={() => navigation.goBack()} className="mr-4 rounded-full border border-[#E4E6EB] p-2">
+          <ArrowLeft size={20} color={sectionTitleColor} />
+        </TouchableOpacity>
+        <Text allowFontScaling={false} className="flex-1 text-center text-xl font-bold" style={{ color: sectionTitleColor }}>
+          My Order
+        </Text>
+        <View className="w-10" />
+      </View>
+
+      <ScrollView
+        contentContainerStyle={{ paddingBottom: 32 }}
+        className="flex-1"
+      >
+        <View className="px-4">
+          <View className="rounded-3xl bg-white">
+            <TouchableOpacity activeOpacity={0.8} className="flex-row items-center justify-between rounded-3xl border border-[#F0F1F3] px-5 py-4">
+              <View>
+                <Text allowFontScaling={false} className="text-sm font-semibold" style={{ color: accentColor }}>
+                  {totalProducts} Product from
+                </Text>
+                <Text allowFontScaling={false} className="text-lg font-bold" style={{ color: accentColor }}>
+                  {restaurantName}
+                </Text>
+              </View>
+              <ChevronDown size={20} color={accentColor} />
+            </TouchableOpacity>
+          </View>
+
+          <Accordion
+            title="I have Allergies"
+            expanded={allergiesExpanded}
+            onToggle={() => setAllergiesExpanded((prev) => !prev)}
+          >
+            <TextInput
+              allowFontScaling={false}
+              multiline
+              placeholder="Add your allergies"
+              placeholderTextColor="#9CA3AF"
+              value={allergies}
+              onChangeText={setAllergies}
+              className="min-h-[80px] rounded-2xl border border-[#F1F2F4] bg-[#F9FAFB] px-4 py-3 text-sm text-[#17213A]"
+              textAlignVertical="top"
+            />
+          </Accordion>
+
+          <Accordion
+            title="Add a comment"
+            expanded={commentExpanded}
+            onToggle={() => setCommentExpanded((prev) => !prev)}
+          >
+            <TextInput
+              allowFontScaling={false}
+              multiline
+              placeholder="Leave a note for the restaurant"
+              placeholderTextColor="#9CA3AF"
+              value={comment}
+              onChangeText={setComment}
+              className="min-h-[80px] rounded-2xl border border-[#F1F2F4] bg-[#F9FAFB] px-4 py-3 text-sm text-[#17213A]"
+              textAlignVertical="top"
+            />
+          </Accordion>
+
+          <View className="mt-6">
+            <Text allowFontScaling={false} className="text-base font-bold" style={{ color: sectionTitleColor }}>
+              Delivery Address
+            </Text>
+            <View className="mt-3 overflow-hidden rounded-3xl border" style={{ borderColor }}>
+              <View style={styles.mapWrapper}>
+                <MapView
+                  style={StyleSheet.absoluteFill}
+                  initialRegion={{
+                    latitude: 36.8625,
+                    longitude: 10.1956,
+                    latitudeDelta: 0.01,
+                    longitudeDelta: 0.01,
+                  }}
+                  scrollEnabled={false}
+                  zoomEnabled={false}
+                  pitchEnabled={false}
+                  rotateEnabled={false}
+                >
+                  <Marker
+                    coordinate={{ latitude: 36.8625, longitude: 10.1956 }}
+                    title="Delivery Address"
+                    description="Rue Mustapha Abdessalem, Ariana 2091"
+                  />
+                </MapView>
+              </View>
+              <View className="flex-row items-start gap-3 bg-white px-4 py-4">
+                <MapPin size={18} color={accentColor} />
+                <Text allowFontScaling={false} className="flex-1 text-sm text-[#4B5563]">
+                  Rue Mustapha Abdessalem, Ariana 2091
+                </Text>
+              </View>
+            </View>
+          </View>
+
+          <View className="mt-6">
+            <Text allowFontScaling={false} className="text-base font-bold" style={{ color: sectionTitleColor }}>
+              Payment method
+            </Text>
+            <TouchableOpacity
+              activeOpacity={0.8}
+              onPress={() => setIsPaymentModalVisible(true)}
+              className="mt-3 flex-row items-center justify-between rounded-3xl border border-[#F0F1F3] bg-white px-5 py-4"
+            >
+              <View className="flex-row items-center">
+                <CreditCard size={22} color={accentColor} />
+                <Text allowFontScaling={false} className="ml-3 text-base font-semibold" style={{ color: sectionTitleColor }}>
+                  {paymentMethod}
+                </Text>
+              </View>
+              <ChevronDown size={20} color={sectionTitleColor} />
+            </TouchableOpacity>
+          </View>
+
+          <TouchableOpacity
+            activeOpacity={0.8}
+            className="mt-4 flex-row items-center justify-between rounded-3xl border border-dashed border-[#F0F1F3] bg-white px-5 py-4"
+          >
+            <View className="flex-row items-center">
+              <TicketPercent size={22} color={accentColor} />
+              <Text allowFontScaling={false} className="ml-3 text-base font-semibold" style={{ color: sectionTitleColor }}>
+                Add Coupon code
+              </Text>
+            </View>
+            <PenSquare size={20} color={sectionTitleColor} />
+          </TouchableOpacity>
+
+          <View className="mt-6 rounded-3xl border border-[#F0F1F3] bg-white p-5">
+            <View className="flex-row items-center justify-between">
+              <Text allowFontScaling={false} className="text-sm text-[#6B7280]">Subtotal</Text>
+              <Text allowFontScaling={false} className="text-sm font-semibold text-[#4B5563]">xx.00 dt</Text>
+            </View>
+            <View className="mt-3 flex-row items-center justify-between">
+              <Text allowFontScaling={false} className="text-sm text-[#6B7280]">Fees</Text>
+              <Text allowFontScaling={false} className="text-sm font-semibold text-[#4B5563]">xx.00 dt</Text>
+            </View>
+            <View className="mt-3 flex-row items-center justify-between">
+              <Text allowFontScaling={false} className="text-sm text-[#6B7280]">Service</Text>
+              <Text allowFontScaling={false} className="text-sm font-semibold text-[#4B5563]">xx.00 dt</Text>
+            </View>
+            <View className="mt-4 border-t border-dashed pt-4" style={{ borderColor }}>
+              <View className="flex-row items-center justify-between">
+                <Text allowFontScaling={false} className="text-lg font-bold" style={{ color: sectionTitleColor }}>
+                  Total
+                </Text>
+                <Text allowFontScaling={false} className="text-lg font-bold" style={{ color: accentColor }}>
+                  xx.00 dt
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </ScrollView>
+
+      <View className="px-4 pb-6">
+        <TouchableOpacity
+          activeOpacity={0.9}
+          className="rounded-full bg-[#CA251B] px-6 py-4"
+        >
+          <Text allowFontScaling={false} className="text-center text-base font-semibold text-white">
+            Confirm and pay to order
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      <PaymentModal
+        visible={isPaymentModalVisible}
+        onClose={() => setIsPaymentModalVisible(false)}
+        onSelect={handlePaymentSelection}
+        selected={paymentMethod}
+      />
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  mapWrapper: {
+    height: 170,
+    width: '100%',
+  },
+});
+
+export default CheckoutOrder;

--- a/src/screens/CouponCode.tsx
+++ b/src/screens/CouponCode.tsx
@@ -1,0 +1,129 @@
+import React, { useMemo, useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { View, Text, TouchableOpacity, TextInput } from 'react-native';
+import { useNavigation, useRoute, NavigationProp, ParamListBase, RouteProp } from '@react-navigation/native';
+import { ArrowLeft, CheckCircle2, XCircle } from 'lucide-react-native';
+
+const sectionTitleColor = '#17213A';
+const accentColor = '#CA251B';
+const borderColor = '#E8E9EC';
+
+type CouponStatus = 'idle' | 'success' | 'error';
+
+type RouteParams = {
+  currentCode?: string;
+};
+
+type CouponRoute = RouteProp<{ CouponCode: RouteParams }, 'CouponCode'>;
+
+const CouponCode: React.FC = () => {
+  const navigation = useNavigation<NavigationProp<ParamListBase>>();
+  const route = useRoute<CouponRoute>();
+  const [couponCode, setCouponCode] = useState(route.params?.currentCode ?? '');
+  const [status, setStatus] = useState<CouponStatus>('idle');
+
+  const helperText = useMemo(() => {
+    if (status === 'success') {
+      return 'Coupon Code valid and applied';
+    }
+
+    if (status === 'error') {
+      return 'Coupon Code not valid please try again';
+    }
+
+    return '';
+  }, [status]);
+
+  const helperColor = status === 'success' ? '#22C55E' : status === 'error' ? accentColor : '#9CA3AF';
+
+  const handleCheckCoupon = () => {
+    if (!couponCode.trim()) {
+      setStatus('error');
+      return;
+    }
+
+    const normalizedCode = couponCode.trim().toUpperCase();
+    setCouponCode(normalizedCode);
+
+    if (normalizedCode === 'ABCDE123') {
+      setStatus('success');
+      navigation.navigate({
+        name: 'CheckoutOrder',
+        params: {
+          couponCode: normalizedCode,
+          discountAmount: 5,
+          couponValid: true,
+        },
+        merge: true,
+      });
+      return;
+    }
+
+    setStatus('error');
+  };
+
+  return (
+    <SafeAreaView className="flex-1 bg-white">
+      <View className="flex-row items-center px-4 pb-4 pt-2">
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          className="mr-4 rounded-full border border-[#E4E6EB] p-2"
+        >
+          <ArrowLeft size={20} color={sectionTitleColor} />
+        </TouchableOpacity>
+        <Text allowFontScaling={false} className="flex-1 text-center text-xl font-bold" style={{ color: sectionTitleColor }}>
+          Coupon code
+        </Text>
+        <View className="w-10" />
+      </View>
+
+      <View className="flex-1 px-6">
+        <Text allowFontScaling={false} className="text-sm font-semibold" style={{ color: sectionTitleColor }}>
+          Add your Coupon
+        </Text>
+        <View className="mt-3 rounded-3xl border px-5 py-4" style={{ borderColor }}>
+          <TextInput
+            allowFontScaling={false}
+            placeholder="ABCDE123"
+            placeholderTextColor="#9CA3AF"
+            value={couponCode}
+            onChangeText={(value) => {
+              setCouponCode(value);
+              setStatus('idle');
+            }}
+            autoCapitalize="characters"
+            autoCorrect={false}
+            className="text-base text-[#17213A]"
+          />
+        </View>
+
+        {helperText ? (
+          <View className="mt-4 flex-row items-center">
+            {status === 'success' ? (
+              <CheckCircle2 size={18} color={helperColor} />
+            ) : (
+              <XCircle size={18} color={helperColor} />
+            )}
+            <Text allowFontScaling={false} className="ml-2 text-sm" style={{ color: helperColor }}>
+              {helperText}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+
+      <View className="px-6 pb-6">
+        <TouchableOpacity
+          activeOpacity={0.9}
+          onPress={handleCheckCoupon}
+          className="rounded-full bg-[#CA251B] px-6 py-4"
+        >
+          <Text allowFontScaling={false} className="text-center text-base font-semibold text-white">
+            Check Coupon code
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default CouponCode;


### PR DESCRIPTION
## Summary
- add a checkout order screen that mirrors the provided design with accordions, delivery map, totals, and confirm button
- display a payment method modal overlay and link it from the cart checkout action
- allow the fixed order bar component to customize its call-to-action label for checkout navigation

## Testing
- npm run lint *(fails: repository already contains unresolved @env imports and other pre-existing lint violations)*

------
https://chatgpt.com/codex/tasks/task_b_68dee57b4dc4832ca3d0a3edad7c1245