### PR TITLE
feat: load restaurant details from api

### DIFF
--- a/src/api/restaurants.ts
+++ b/src/api/restaurants.ts
@@ -1,5 +1,9 @@
 import client from './client';
-import type { NearbyRestaurantsParams, RestaurantSummary } from '~/interfaces/Restaurant';
+import type {
+  NearbyRestaurantsParams,
+  RestaurantDetailsResponse,
+  RestaurantSummary,
+} from '~/interfaces/Restaurant';
 
 export const getNearbyRestaurants = async ({ lat, lng, radiusKm = 1 }: NearbyRestaurantsParams): Promise<RestaurantSummary[]> => {
   const { data } = await client.get<RestaurantSummary[]>('/client/nearby', {
@@ -10,5 +14,10 @@ export const getNearbyRestaurants = async ({ lat, lng, radiusKm = 1 }: NearbyRes
     },
   });
 
+  return data;
+};
+
+export const getRestaurantDetails = async (id: number): Promise<RestaurantDetailsResponse> => {
+  const { data } = await client.get<RestaurantDetailsResponse>(`/client/restaurant/${id}`);
   return data;
 };

--- a/src/interfaces/Restaurant/index.ts
+++ b/src/interfaces/Restaurant/index.ts
@@ -1,28 +1,67 @@
-export interface MenuItemExtra {
+export interface RestaurantBadge {
+  label: string;
+  value: string;
+}
+
+export interface RestaurantMenuItemExtra {
   id: number;
   name: string;
   price: number;
-  isDefault: boolean;
+  defaultOption: boolean;
 }
 
-export interface MenuOptionGroup {
+export interface RestaurantMenuOptionGroup {
   id: number;
   name: string;
   minSelect: number;
   maxSelect: number;
   required: boolean;
-  extras: MenuItemExtra[];
+  extras: RestaurantMenuItemExtra[];
 }
 
-export interface MenuItem {
+export interface RestaurantMenuItemDetails {
   id: number;
   name: string;
   description: string;
-  category: string;
-  isPopular: boolean;
   price: number;
-  imageUrls: string[];
-  optionGroups: MenuOptionGroup[];
+  imageUrl: string;
+  popular: boolean;
+  tags: string[];
+  optionGroups: RestaurantMenuOptionGroup[];
+}
+
+export interface RestaurantMenuCategory {
+  name: string;
+  items: RestaurantMenuItemDetails[];
+}
+
+export interface RestaurantMenuItemSummary {
+  id: number;
+  name: string;
+  description: string;
+  price: number;
+  imageUrl: string;
+  popular: boolean;
+  tags: string[];
+}
+
+export interface RestaurantDetailsResponse {
+  id: number;
+  name: string;
+  description: string;
+  imageUrl: string;
+  address: string;
+  phone: string;
+  type: string;
+  rating: string;
+  openingHours: string;
+  closingHours: string;
+  latitude: number;
+  longitude: number;
+  highlights: RestaurantBadge[];
+  quickFilters: string[];
+  topSales: RestaurantMenuItemSummary[];
+  categories: RestaurantMenuCategory[];
 }
 
 export interface RestaurantSummary {
@@ -40,7 +79,7 @@ export interface RestaurantSummary {
   latitude: number;
   longitude: number;
   imageUrl: string;
-  menu: MenuItem[];
+  menu: RestaurantMenuItemDetails[];
 }
 
 export interface NearbyRestaurantsParams {

--- a/src/screens/MenuDetail.tsx
+++ b/src/screens/MenuDetail.tsx
@@ -1,13 +1,19 @@
-import React, { useState } from "react";
-import { View, Text, TouchableOpacity, Dimensions, ScrollView } from "react-native";
-import { X, Heart, Check, Plus, Minus, ArrowLeft } from "lucide-react-native";
-import { Image } from "expo-image";
-import MainLayout from "~/layouts/MainLayout";
-import { useNavigation } from "@react-navigation/native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import React, { useEffect, useMemo, useState } from 'react';
+import { View, Text, TouchableOpacity, Dimensions, ScrollView } from 'react-native';
+import { X, Heart, Check, Plus, Minus, ArrowLeft } from 'lucide-react-native';
+import { Image } from 'expo-image';
+import MainLayout from '~/layouts/MainLayout';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-const { width } = Dimensions.get("window");
-const primaryColor = "#CA251B";
+import type {
+  RestaurantMenuItemDetails,
+  RestaurantMenuItemExtra,
+  RestaurantMenuOptionGroup,
+} from '~/interfaces/Restaurant';
+import { BASE_API_URL } from '@env';
+
+const { width } = Dimensions.get('window');
+const primaryColor = '#CA251B';
 
 interface CartItemDetails {
   quantity: number;
@@ -15,112 +21,166 @@ interface CartItemDetails {
 }
 
 interface MenuDetailProps {
+  menuItem: RestaurantMenuItemDetails;
   handleAddItem: (itemDetails: CartItemDetails) => void;
+  onClose?: () => void;
 }
 
 interface OptionRowProps {
-  item: string;
-  displayItem: string;
+  group: RestaurantMenuOptionGroup;
+  extra: RestaurantMenuItemExtra;
   isSelected: boolean;
-  onToggle: (name: string) => void;
-  price?: number;
+  onToggle: (group: RestaurantMenuOptionGroup, extra: RestaurantMenuItemExtra) => void;
 }
 
-const OptionRow: React.FC<OptionRowProps> = ({
-  item,
-  displayItem,
-  isSelected,
-  onToggle,
-  price,
-}) => {
-  const formatPrice = (p: number) => p.toFixed(3).replace(".", ",");
+const formatPrice = (p: number) => `${p.toFixed(3).replace('.', ',')} DT`;
 
-  return (
-    <TouchableOpacity
-      onPress={() => onToggle(item)}
-      className="flex-row justify-between items-center mb-4"
-    >
-      <View className="flex-row items-center flex-1">
-        <Text allowFontScaling={false} className="text-gray-800 text-base font-semibold">
-          {displayItem}
-        </Text>
-        {price !== undefined && (
-          <View className="bg-red-700 rounded-lg px-2 py-1 ml-2">
-            <Text allowFontScaling={false} className="text-white text-xs font-bold">
-              +{formatPrice(price)} DT
-            </Text>
-          </View>
-        )}
-      </View>
-
-      <View
-        style={{
-          width: 24,
-          height: 24,
-          borderRadius: 12,
-          borderWidth: 1,
-          borderColor: primaryColor,
-          backgroundColor: isSelected ? primaryColor : "transparent",
-        }}
-        className="flex items-center justify-center"
-      >
-        {isSelected ? (
-          <Check size={16} color="white" />
-        ) : (
-          <Plus size={16} color={primaryColor} />
-        )}
-      </View>
-    </TouchableOpacity>
-  );
+const resolveImageSource = (imagePath?: string | null) => {
+  if (imagePath) {
+    return { uri: `${BASE_API_URL}/auth/image/${imagePath}` };
+  }
+  return require('../../assets/baguette.png');
 };
 
-export default function MenuDetail({ handleAddItem }: MenuDetailProps) {
-  const navigation = useNavigation();
-  const basePrice = 19.3;
-  const initialDescription =
-    "2 galette tortillas à la farine de blé, 2 viandes au choix, sauce fromagère, garniture et frites.";
+const OptionRow: React.FC<OptionRowProps> = ({ group, extra, isSelected, onToggle }) => (
+  <TouchableOpacity onPress={() => onToggle(group, extra)} className="mb-4 flex-row items-center justify-between">
+    <View className="flex-1 flex-row items-center">
+      <Text allowFontScaling={false} className="text-base font-semibold text-gray-800">
+        {extra.name}
+      </Text>
+      {extra.price > 0 ? (
+        <View className="ml-2 rounded-lg bg-[#CA251B] px-2 py-1">
+          <Text allowFontScaling={false} className="text-xs font-bold text-white">
+            +{formatPrice(extra.price)}
+          </Text>
+        </View>
+      ) : null}
+    </View>
+
+    <View
+      style={{
+        width: 24,
+        height: 24,
+        borderRadius: 12,
+        borderWidth: 1,
+        borderColor: primaryColor,
+        backgroundColor: isSelected ? primaryColor : 'transparent',
+      }}
+      className="flex items-center justify-center">
+      {isSelected ? <Check size={16} color="white" /> : <Plus size={16} color={primaryColor} />}
+    </View>
+  </TouchableOpacity>
+);
+
+const buildInitialSelection = (item: RestaurantMenuItemDetails) => {
+  const selections: Record<number, number[]> = {};
+
+  item.optionGroups.forEach((group) => {
+    const defaults = group.extras.filter((extra) => extra.defaultOption).map((extra) => extra.id);
+
+    if (defaults.length > 0) {
+      selections[group.id] = defaults;
+      return;
+    }
+
+    if (group.required && group.minSelect > 0) {
+      selections[group.id] = group.extras.slice(0, group.minSelect).map((extra) => extra.id);
+      return;
+    }
+
+    selections[group.id] = [];
+  });
+
+  return selections;
+};
+
+const calculateExtrasTotal = (
+  optionGroups: RestaurantMenuOptionGroup[],
+  selections: Record<number, number[]>
+) =>
+  optionGroups.reduce((sum, group) => {
+    const selectedIds = selections[group.id] ?? [];
+    const groupTotal = group.extras.reduce((groupSum, extra) => {
+      if (selectedIds.includes(extra.id)) {
+        return groupSum + extra.price;
+      }
+      return groupSum;
+    }, 0);
+    return sum + groupTotal;
+  }, 0);
+
+const isSelectionValid = (
+  optionGroups: RestaurantMenuOptionGroup[],
+  selections: Record<number, number[]>
+) =>
+  optionGroups.every((group) => {
+    const selectedCount = selections[group.id]?.length ?? 0;
+    const minRequired = group.required ? Math.max(group.minSelect, 1) : group.minSelect;
+    return selectedCount >= minRequired;
+  });
+
+const MenuDetail: React.FC<MenuDetailProps> = ({ menuItem, handleAddItem, onClose }) => {
+  const insets = useSafeAreaInsets();
 
   const [quantity, setQuantity] = useState(1);
-  const [selectedToppings, setSelectedToppings] = useState<string[]>(["Onion"]);
-  const [selectedMeats, setSelectedMeats] = useState<string[]>([]);
-  const [selectedSupplements, setSelectedSupplements] = useState<string[]>([]);
-    const insets = useSafeAreaInsets();
+  const [selections, setSelections] = useState<Record<number, number[]>>(() => buildInitialSelection(menuItem));
 
-  const toppingsList = ["Lettuce", "Caramelised onion", "Onion"];
-  const meatsList = ["Cordon bleu", "Toasted escalope", "Kebab", "Nuggets"];
-  const supplementsList = [
-    { name: "Cheddar", price: 3.0 },
-    { name: "Mozzarella", price: 3.0 },
-    { name: "Bacon", price: 3.0 },
-  ];
+  useEffect(() => {
+    setQuantity(1);
+    setSelections(buildInitialSelection(menuItem));
+  }, [menuItem]);
 
-  const calculateTotal = () => {
-    const supPrice = selectedSupplements.reduce((sum, name) => {
-      const sup = supplementsList.find((s) => s.name === name);
-      return sum + (sup ? sup.price : 0);
-    }, 0);
-    return (basePrice + supPrice) * quantity;
+  const toggleExtra = (group: RestaurantMenuOptionGroup, extra: RestaurantMenuItemExtra) => {
+    setSelections((prev) => {
+      const current = prev[group.id] ?? [];
+      const isSelected = current.includes(extra.id);
+
+      if (isSelected) {
+        const minRequired = group.required ? Math.max(group.minSelect, 1) : group.minSelect;
+        if (current.length <= minRequired) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [group.id]: current.filter((id) => id !== extra.id),
+        };
+      }
+
+      if (group.maxSelect > 0 && current.length >= group.maxSelect) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        [group.id]: [...current, extra.id],
+      };
+    });
   };
 
-  const total = calculateTotal();
-  const formatPrice = (p: number) => p.toFixed(3).replace(".", ",");
+  const extrasTotal = useMemo(
+    () => calculateExtrasTotal(menuItem.optionGroups, selections),
+    [menuItem.optionGroups, selections]
+  );
+
+  const itemTotal = useMemo(() => (menuItem.price + extrasTotal) * quantity, [menuItem.price, extrasTotal, quantity]);
+
+  const canAddToCart = useMemo(
+    () => isSelectionValid(menuItem.optionGroups, selections),
+    [menuItem.optionGroups, selections]
+  );
 
   const handleAdd = () => {
-    handleAddItem({ quantity, total });
+    if (!canAddToCart) {
+      return;
+    }
+    handleAddItem({ quantity, total: itemTotal });
   };
 
   const detailHeader = (
     <View>
-      <Image
-        source={require("../../assets/TEST.png")}
-        style={{ width, height: '100%' }}
-        contentFit="cover"
-      />
+      <Image source={resolveImageSource(menuItem.imageUrl)} style={{ width, height: '100%' }} contentFit="cover" />
       <View className="absolute left-4 top-8">
-        <TouchableOpacity
-          className="rounded-full bg-white p-2"
-          onPress={() => navigation.goBack()}
-        >
+        <TouchableOpacity className="rounded-full bg-white p-2" onPress={onClose}>
           <X size={20} color={primaryColor} />
         </TouchableOpacity>
       </View>
@@ -133,12 +193,12 @@ export default function MenuDetail({ handleAddItem }: MenuDetailProps) {
   );
 
   const collapsedHeader = (
-    <View className="flex-1 justify-center bg-white px-4 flex-row items-center">
-      <TouchableOpacity className="p-2" onPress={() =>console.log('here')}>
+    <View className="flex-1 flex-row items-center justify-center bg-white px-4">
+      <TouchableOpacity className="p-2" onPress={onClose}>
         <ArrowLeft size={20} color={primaryColor} />
       </TouchableOpacity>
-      <Text allowFontScaling={false} className="text-lg font-bold text-gray-800 flex-1 text-center">
-        Di Napoli
+      <Text allowFontScaling={false} className="flex-1 text-center text-lg font-bold text-gray-800">
+        {menuItem.name}
       </Text>
       <TouchableOpacity className="p-2">
         <Heart size={20} color={primaryColor} />
@@ -147,96 +207,79 @@ export default function MenuDetail({ handleAddItem }: MenuDetailProps) {
   );
 
   const mainContent = (
-    <ScrollView className="px-4 -mt-4 bg-white rounded-t-2xl pt-4" contentContainerStyle={{paddingBottom: 50}}>
-      <Text allowFontScaling={false} className="text-3xl font-bold text-[#17213A] mt-2">Tacos XL</Text>
-      <Text allowFontScaling={false} className="text-xl font-bold text-[#CA251B] mt-1">
-        {formatPrice(basePrice)} DT
+    <ScrollView className="-mt-4 rounded-t-2xl bg-white px-4 pt-4" contentContainerStyle={{ paddingBottom: 120 }}>
+      <Text allowFontScaling={false} className="mt-2 text-3xl font-bold text-[#17213A]">
+        {menuItem.name}
       </Text>
-      <Text allowFontScaling={false} className="text-sm text-[#17213A] mt-2 mb-6">
-        {initialDescription}
+      <Text allowFontScaling={false} className="mt-1 text-xl font-bold text-[#CA251B]">
+        {formatPrice(menuItem.price)}
       </Text>
+      {menuItem.description ? (
+        <Text allowFontScaling={false} className="mt-2 mb-4 text-sm text-[#17213A]">
+          {menuItem.description}
+        </Text>
+      ) : null}
 
-      <Text allowFontScaling={false} className="text-xl font-bold mb-1">Choose your toppings</Text>
-      {toppingsList.map((item) => (
-        <OptionRow
-          key={item}
-          item={item}
-          displayItem={item}
-          isSelected={selectedToppings.includes(item)}
-          onToggle={(n) =>
-            setSelectedToppings((prev) =>
-              prev.includes(n) ? prev.filter((t) => t !== n) : [...prev, n]
-            )
-          }
-        />
+      {menuItem.tags?.length ? (
+        <View className="mb-4 flex-row flex-wrap gap-2">
+          {menuItem.tags.map((tag) => (
+            <View key={tag} className="rounded-full bg-[#FDE7E5] px-3 py-1">
+              <Text allowFontScaling={false} className="text-xs font-semibold text-[#CA251B]">
+                {tag}
+              </Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      {menuItem.optionGroups.map((group) => (
+        <View key={group.id} className="mb-6">
+          <View className="mb-2 flex-row items-center justify-between">
+            <Text allowFontScaling={false} className="text-xl font-bold text-[#17213A]">
+              {group.name}
+            </Text>
+            <Text allowFontScaling={false} className="text-xs text-gray-500">
+              {group.required ? 'Required' : 'Optional'}
+              {group.maxSelect > 0 ? ` · Choose up to ${group.maxSelect}` : ''}
+            </Text>
+          </View>
+          {group.extras.map((extra) => (
+            <OptionRow
+              key={extra.id}
+              group={group}
+              extra={extra}
+              isSelected={(selections[group.id] ?? []).includes(extra.id)}
+              onToggle={toggleExtra}
+            />
+          ))}
+        </View>
       ))}
-
-      <View className="h-[1px] bg-gray-200 my-4" />
-
-      <Text allowFontScaling={false} className="text-xl font-bold mb-1">Choose your meat</Text>
-      {meatsList.map((item) => (
-        <OptionRow
-          key={item}
-          item={item}
-          displayItem={item}
-          isSelected={selectedMeats.includes(item)}
-          onToggle={(n) =>
-            setSelectedMeats((prev) =>
-              prev.includes(n) ? prev.filter((m) => m !== n) : [...prev, n]
-            )
-          }
-        />
-      ))}
-
-      <View className="h-[1px] bg-gray-200 my-4" />
-
-      <Text allowFontScaling={false} className="text-xl font-bold mb-1">Supplements</Text>
-      {supplementsList.map((item) => (
-        <OptionRow
-          key={item.name}
-          item={item.name}
-          displayItem={item.name}
-          isSelected={selectedSupplements.includes(item.name)}
-          onToggle={(n) =>
-            setSelectedSupplements((prev) =>
-              prev.includes(n) ? prev.filter((s) => s !== n) : [...prev, n]
-            )
-          }
-          price={item.price}
-        />
-      ))}
-
-      <View className="h-20" />
     </ScrollView>
   );
 
   const orderBar = (
-    <View style={{paddingBottom: insets.bottom}} className="absolute bottom-0 left-0 right-0 w-full bg-white p-4 shadow-2xl border-t border-gray-100">
-      <View className="flex-row items-center justify-center mb-4">
+    <View style={{ paddingBottom: insets.bottom }} className="absolute bottom-0 left-0 right-0 w-full border-t border-gray-100 bg-white p-4 shadow-2xl">
+      <View className="mb-4 flex-row items-center justify-center">
         <TouchableOpacity
           onPress={() => setQuantity((q) => Math.max(1, q - 1))}
-          className={`p-2 rounded-full border border-[#CA251B] ${
-            quantity > 1 ? "bg-[#CA251B]" : "bg-transparent"
-          }`}
-          disabled={quantity <= 1}
-        >
-          <Minus size={24} color={quantity > 1 ? "white" : primaryColor} />
+          className={`rounded-full border border-[#CA251B] p-2 ${quantity > 1 ? 'bg-[#CA251B]' : 'bg-transparent'}`}
+          disabled={quantity <= 1}>
+          <Minus size={24} color={quantity > 1 ? 'white' : primaryColor} />
         </TouchableOpacity>
-        <Text allowFontScaling={false} className="text-2xl font-bold mx-6">{quantity}</Text>
-        <TouchableOpacity
-          onPress={() => setQuantity((q) => q + 1)}
-          className="bg-[#CA251B] p-2 rounded-full border border-[#CA251B]"
-        >
+        <Text allowFontScaling={false} className="mx-6 text-2xl font-bold">
+          {quantity}
+        </Text>
+        <TouchableOpacity onPress={() => setQuantity((q) => q + 1)} className="rounded-full border border-[#CA251B] bg-[#CA251B] p-2">
           <Plus size={24} color="white" />
         </TouchableOpacity>
       </View>
 
       <TouchableOpacity
-        className="w-full bg-[#CA251B] py-4 rounded-xl shadow-lg"
+        className={`w-full rounded-xl py-4 shadow-lg ${canAddToCart ? 'bg-[#CA251B]' : 'bg-gray-300'}`}
         onPress={handleAdd}
-      >
-        <Text allowFontScaling={false} className="text-white text-lg font-bold text-center">
-          Add {quantity} for {formatPrice(total)} DT
+        disabled={!canAddToCart}>
+        <Text allowFontScaling={false} className="text-center text-lg font-bold text-white">
+          Add {quantity} for {formatPrice(itemTotal)}
         </Text>
       </TouchableOpacity>
     </View>
@@ -256,4 +299,6 @@ export default function MenuDetail({ handleAddItem }: MenuDetailProps) {
       {orderBar}
     </View>
   );
-}
+};
+
+export default MenuDetail;

--- a/src/screens/RestaurantDetails.tsx
+++ b/src/screens/RestaurantDetails.tsx
@@ -1,14 +1,31 @@
-import { Clock7, Plus, Star, MapPin, Heart, ArrowLeft } from 'lucide-react-native';
-import { useState, useEffect, useCallback } from 'react';
-import { View, Text, ScrollView, TouchableOpacity, Dimensions, StyleSheet } from 'react-native';
-import MainLayout from '~/layouts/MainLayout';
-import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
-import { useNavigation, NavigationProp, ParamListBase } from '@react-navigation/native';
+import { ArrowLeft, Clock7, Heart, MapPin, Plus, Star } from 'lucide-react-native';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Dimensions,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { Image } from 'expo-image';
-import MenuDetail from './MenuDetail';
+import { NavigationProp, ParamListBase, RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useQuery } from '@tanstack/react-query';
+
+import MainLayout from '~/layouts/MainLayout';
 import FixedOrderBar from '~/components/FixedOrderBar';
-import { vs } from 'react-native-size-matters';
+import MenuDetail from './MenuDetail';
+import { getRestaurantDetails } from '~/api/restaurants';
+import type {
+  RestaurantDetailsResponse,
+  RestaurantMenuCategory,
+  RestaurantMenuItemDetails,
+  RestaurantMenuItemSummary,
+} from '~/interfaces/Restaurant';
+import { BASE_API_URL } from '@env';
 
 const { width, height: screenHeight } = Dimensions.get('screen');
 const modalHeight = screenHeight;
@@ -18,24 +35,30 @@ interface CartItemDetails {
   total: number;
 }
 
-interface MenuItem {
-  name: string;
-  description: string;
-  price: string;
+interface RestaurantDetailsRouteParams {
+  RestaurantDetails: {
+    restaurantId: number;
+  };
 }
 
-const MenuItemCard: React.FC<{ item: MenuItem; onOpenModal: () => void }> = ({
-  item,
-  onOpenModal,
-}) => (
-  <View
-    style={{ width: width / 2 - 24 }}
-    className="flex flex-col overflow-hidden rounded-xl bg-white shadow-md">
-    <Image
-      source={require('../../assets/baguette.png')}
-      style={{ width: '100%', height: 100 }}
-      contentFit="cover"
-    />
+type RestaurantDetailsRouteProp = RouteProp<RestaurantDetailsRouteParams, 'RestaurantDetails'>;
+
+type MenuCardItem = RestaurantMenuItemDetails | RestaurantMenuItemSummary;
+
+const FALLBACK_IMAGE = require('../../assets/baguette.png');
+
+const formatCurrency = (value: number) => `${value.toFixed(3).replace('.', ',')} DT`;
+
+const resolveImageSource = (imagePath?: string | null) => {
+  if (imagePath) {
+    return { uri: `${BASE_API_URL}/auth/image/${imagePath}` };
+  }
+  return FALLBACK_IMAGE;
+};
+
+const MenuItemCard: React.FC<{ item: MenuCardItem; onOpenModal: (itemId: number) => void }> = ({ item, onOpenModal }) => (
+  <View style={{ width: width / 2 - 24 }} className="flex flex-col overflow-hidden rounded-xl bg-white shadow-md">
+    <Image source={resolveImageSource(item.imageUrl)} style={{ width: '100%', height: 110 }} contentFit="cover" />
 
     <View className="flex flex-col gap-1 p-3">
       <Text allowFontScaling={false} className="text-sm font-bold text-[#17213A]" numberOfLines={1}>
@@ -47,12 +70,10 @@ const MenuItemCard: React.FC<{ item: MenuItem; onOpenModal: () => void }> = ({
 
       <View className="mt-2 flex-row items-center justify-between">
         <Text allowFontScaling={false} className="font-bold text-[#CA251B]">
-          {item.price}
+          {formatCurrency(item.price)}
         </Text>
 
-        <TouchableOpacity
-          className="rounded-full bg-[#CA251B] p-1.5 text-white shadow-md"
-          onPress={onOpenModal}>
+        <TouchableOpacity className="rounded-full bg-[#CA251B] p-1.5 text-white shadow-md" onPress={() => onOpenModal(item.id)}>
           <Plus size={18} color="white" />
         </TouchableOpacity>
       </View>
@@ -60,50 +81,40 @@ const MenuItemCard: React.FC<{ item: MenuItem; onOpenModal: () => void }> = ({
   </View>
 );
 
-const STATIC_MENU_ITEMS: MenuItem[] = [
-  {
-    name: 'Pizza 1/4 Plateau Thon Fromage',
-    description: 'Sauce tomate, thon, fromage, persil - Portion 2 Personnes',
-    price: '19,300 DT',
-  },
-  {
-    name: 'Sandwich Tunisien Complet',
-    description: 'Merguez, œuf, salade méchouia, harissa, frites',
-    price: '8,500 DT',
-  },
-  {
-    name: 'Lablebi Classique',
-    description: "Pois chiches, cumin, huile d'olive, œufs pochés",
-    price: '5,000 DT',
-  },
-  {
-    name: "Jus d'Orange Frais",
-    description: "Jus d'orange 100% naturel pressé à la minute",
-    price: '4,000 DT',
-  },
-  {
-    name: 'Salade César',
-    description: 'Laitue, croûtons, parmesan, poulet grillé, sauce César',
-    price: '12,000 DT',
-  },
-  {
-    name: 'Tiramisu',
-    description: 'Dessert italien classique au café et mascarpone',
-    price: '7,500 DT',
-  },
-];
-const TABS = ['Top Sales', 'Pizza Tranches', 'Pizza', 'Sandwich'];
+const flattenCategories = (categories: RestaurantMenuCategory[]) =>
+  categories.reduce<RestaurantMenuItemDetails[]>((acc, category) => acc.concat(category.items), []);
+
+const mapSummaryToDetails = (summary: RestaurantMenuItemSummary): RestaurantMenuItemDetails => ({
+  ...summary,
+  optionGroups: [],
+});
 
 export default function RestaurantDetails() {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [cartVisible, setCartVisible] = useState(false);
   const [cartTotal, setCartTotal] = useState({ price: '0,000 DT', count: 0 });
-  const [barHeight, setBarHeight] = useState(0);
+  const [selectedMenuItem, setSelectedMenuItem] = useState<RestaurantMenuItemDetails | null>(null);
 
   const insets = useSafeAreaInsets();
 
   const translateY = useSharedValue(modalHeight);
   const navigation = useNavigation<NavigationProp<ParamListBase>>();
+  const route = useRoute<RestaurantDetailsRouteProp>();
+  const restaurantId = route.params?.restaurantId;
+  const isRestaurantIdValid = typeof restaurantId === 'number' && !Number.isNaN(restaurantId);
+
+  const {
+    data: restaurant,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery<RestaurantDetailsResponse>({
+    queryKey: ['restaurant-details', restaurantId],
+    queryFn: () => getRestaurantDetails(restaurantId as number),
+    enabled: isRestaurantIdValid,
+  });
+
+  const allMenuItems = useMemo(() => (restaurant ? flattenCategories(restaurant.categories) : []), [restaurant]);
 
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ translateY: translateY.value }],
@@ -115,14 +126,38 @@ export default function RestaurantDetails() {
     }
   }, [isModalVisible, translateY]);
 
-  const handleOpen = useCallback(() => {
-    setIsModalVisible(true);
-  }, []);
+  const handleOpenMenuItem = useCallback(
+    (itemId: number) => {
+      if (!restaurant) {
+        return;
+      }
+
+      const detailedItem = allMenuItems.find((item) => item.id === itemId);
+      if (detailedItem) {
+        setSelectedMenuItem(detailedItem);
+        setIsModalVisible(true);
+        return;
+      }
+
+      const topSaleMatch = restaurant.topSales.find((item) => item.id === itemId);
+      if (topSaleMatch) {
+        setSelectedMenuItem(mapSummaryToDetails(topSaleMatch));
+        setIsModalVisible(true);
+      }
+    },
+    [allMenuItems, restaurant]
+  );
+
+  const handleOpen = useCallback(
+    (itemId: number) => {
+      handleOpenMenuItem(itemId);
+    },
+    [handleOpenMenuItem]
+  );
 
   const handleUpdateCartAndClose = useCallback(
     (itemDetails: CartItemDetails) => {
       if (itemDetails.quantity > 0) {
-        // Convert price string to number for calculation
         const currentTotalNum = parseFloat(cartTotal.price.replace(',', '.')) || 0;
         const newTotalNum = currentTotalNum + itemDetails.total;
         const newCount = cartTotal.count + itemDetails.quantity;
@@ -134,119 +169,219 @@ export default function RestaurantDetails() {
         setCartVisible(true);
       }
       setIsModalVisible(false);
+      setSelectedMenuItem(null);
     },
-    [cartTotal, translateY]
+    [cartTotal]
   );
 
   const handleSeeCart = () => {
     navigation.navigate('Cart');
   };
 
-  const modalContent = <MenuDetail handleAddItem={handleUpdateCartAndClose} />;
+  const renderHighlights = () => {
+    if (!restaurant?.highlights?.length) {
+      return null;
+    }
 
-  const mainContent = (
-    <View>
-      <View className="px-4 ">
-        <Text allowFontScaling={false} className="ml-2 mt-4 text-2xl font-bold text-[#17213A]">
-          Di Napoli
-        </Text>
-        <Text allowFontScaling={false} className="ml-2 mt-4 text-sm text-[#17213A]">
-          Pizzas en tranches, Plats exquis, sandwich!!
-        </Text>
-
-        <View className="mt-2 flex flex-row items-center justify-center text-xs text-[#17213A]">
-          <View className="border-1 mt-2 flex flex-row items-center gap-4 rounded-xl border-black/5 bg-white px-4 py-2 shadow-xl">
-            <View className="flex flex-row items-center gap-1 font-sans">
-              <Clock7 size={16} color="#CA251B" />
-              <Text allowFontScaling={false} className="text-sm text-gray-700">
-                25 - 30 mins
-              </Text>
-            </View>
-
-            <View className="flex flex-row items-center gap-1 font-sans">
-              <Text allowFontScaling={false} className="text-sm text-gray-700">
-                4.9
-              </Text>
-              <Star size={16} color="#CA251B" fill="#CA251B" />
-            </View>
-
-            <View className="flex flex-row items-center gap-1 font-sans">
-              <MapPin size={16} color="#CA251B" />
-              <Text allowFontScaling={false} className="text-sm text-gray-700">
-                1,5 DT
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-
-      <View className="mb-4 mt-4 rounded-lg bg-gray-100">
-        <View className="p-3 px-4">
-          <Text allowFontScaling={false} className="mb-1 font-semibold text-[#17213A]">
-            Restaurant Info
-          </Text>
-          <Text allowFontScaling={false} className="text-sm text-[#17213A]">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-          </Text>
-          <View className="ml-2 mt-2 flex flex-row items-center text-[#17213A]/40">
-            <MapPin size={20} />
-            <Text allowFontScaling={false} className="ml-2 text-[#17213A]">
-              Rue Mustapha Abdessalem, Ariana 2091
+    return (
+      <View className="mt-3 flex-row flex-wrap gap-2">
+        {restaurant.highlights.map((highlight) => (
+          <View key={`${highlight.label}-${highlight.value}`} className="rounded-full bg-[#FDE7E5] px-3 py-1">
+            <Text allowFontScaling={false} className="text-xs font-semibold text-[#CA251B]">
+              {highlight.label}: {highlight.value}
             </Text>
           </View>
-        </View>
+        ))}
       </View>
+    );
+  };
 
+  const renderQuickFilters = () => {
+    if (!restaurant?.quickFilters?.length) {
+      return null;
+    }
+
+    return (
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} className="scrollbar-hide flex gap-2 overflow-x-auto p-4 py-2">
+        {restaurant.quickFilters.map((filter, idx) => (
+          <View
+            key={`${filter}-${idx}`}
+            className={`mr-2 rounded-xl border border-[#CA251B] px-4 py-2 ${idx === 0 ? 'bg-[#CA251B]' : 'bg-white'}`}>
+            <Text
+              allowFontScaling={false}
+              className={`font-['roboto'] text-sm font-semibold ${idx === 0 ? 'text-white' : 'text-[#CA251B]'}`}>
+              {filter}
+            </Text>
+          </View>
+        ))}
+      </ScrollView>
+    );
+  };
+
+  const renderTopSales = () => {
+    if (!restaurant?.topSales?.length) {
+      return null;
+    }
+
+    return (
       <View className="px-4">
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          className="scrollbar-hide flex gap-2 overflow-x-auto p-4 py-2">
-          {TABS.map((cat, idx) => (
-            <TouchableOpacity
-              key={idx}
-              className={`mr-2 rounded-xl border border-[#CA251B] px-4 py-2 ${idx === 0 ? 'bg-[#CA251B]' : 'bg-white'}`}>
-              <Text
-                allowFontScaling={false}
-                className={`font-['roboto'] text-sm font-semibold ${idx === 0 ? 'text-white' : 'text-[#CA251B]'}`}>
-                {cat}
-              </Text>
-            </TouchableOpacity>
-          ))}
-        </ScrollView>
-
         <Text allowFontScaling={false} className="mb-4 text-lg font-semibold text-black/60">
-          Top Sales ({STATIC_MENU_ITEMS.length})
+          Top Sales ({restaurant.topSales.length})
         </Text>
 
         <View className="mb-4 flex-row flex-wrap justify-between gap-y-4">
-          {STATIC_MENU_ITEMS.map((item, idx) => (
-            <View key={idx} className="shadow-3xl overflow-hidden rounded-3xl ">
+          {restaurant.topSales.map((item) => (
+            <View key={item.id} className="overflow-hidden rounded-3xl shadow-3xl">
               <MenuItemCard item={item} onOpenModal={handleOpen} />
             </View>
           ))}
         </View>
-
-        <View style={{ height: barHeight }} />
       </View>
-    </View>
-  );
+    );
+  };
+
+  const renderCategories = () => {
+    if (!restaurant?.categories?.length) {
+      return null;
+    }
+
+    return (
+      <View className="px-4">
+        {restaurant.categories.map((category) => (
+          <View key={category.name} className="mb-8">
+            <Text allowFontScaling={false} className="mb-4 text-lg font-semibold text-[#17213A]">
+              {category.name}
+            </Text>
+            <View className="flex-row flex-wrap justify-between gap-y-4">
+              {category.items.map((item) => (
+                <View key={item.id} className="overflow-hidden rounded-3xl shadow-3xl">
+                  <MenuItemCard item={item} onOpenModal={handleOpen} />
+                </View>
+              ))}
+            </View>
+          </View>
+        ))}
+      </View>
+    );
+  };
+
+  const mainContent = () => {
+    if (!isRestaurantIdValid) {
+      return (
+        <View className="flex-1 items-center justify-center px-6 py-20">
+          <Text allowFontScaling={false} className="mb-4 text-center text-lg font-semibold text-[#17213A]">
+            No restaurant selected.
+          </Text>
+          <TouchableOpacity
+            onPress={() => navigation.goBack()}
+            className="rounded-full bg-[#CA251B] px-6 py-3">
+            <Text allowFontScaling={false} className="text-white">
+              Go back
+            </Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
+
+    if (isLoading) {
+      return (
+        <View className="flex-1 items-center justify-center py-20">
+          <ActivityIndicator size="large" color="#CA251B" />
+        </View>
+      );
+    }
+
+    if (isError || !restaurant) {
+      return (
+        <View className="flex-1 items-center justify-center px-6 py-20">
+          <Text allowFontScaling={false} className="mb-4 text-center text-lg font-semibold text-[#17213A]">
+            We could not load this restaurant.
+          </Text>
+          <TouchableOpacity
+            onPress={() => refetch()}
+            className="rounded-full bg-[#CA251B] px-6 py-3">
+            <Text allowFontScaling={false} className="text-white">
+              Retry
+            </Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
+
+    return (
+      <View>
+        <View className="px-4">
+          <Text allowFontScaling={false} className="ml-2 mt-4 text-2xl font-bold text-[#17213A]">
+            {restaurant.name}
+          </Text>
+          {restaurant.description ? (
+            <Text allowFontScaling={false} className="ml-2 mt-2 text-sm text-[#17213A]">
+              {restaurant.description}
+            </Text>
+          ) : null}
+
+          <View className="mt-3 flex flex-row items-center justify-center text-xs text-[#17213A]">
+            <View className="border-1 mt-2 flex flex-row items-center gap-4 rounded-xl border-black/5 bg-white px-4 py-2 shadow-xl">
+              <View className="flex flex-row items-center gap-1 font-sans">
+                <Clock7 size={16} color="#CA251B" />
+                <Text allowFontScaling={false} className="text-sm text-gray-700">
+                  {restaurant.openingHours} - {restaurant.closingHours}
+                </Text>
+              </View>
+
+              <View className="flex flex-row items-center gap-1 font-sans">
+                <Text allowFontScaling={false} className="text-sm text-gray-700">
+                  {restaurant.rating || 'New'}
+                </Text>
+                <Star size={16} color="#CA251B" fill="#CA251B" />
+              </View>
+
+              <View className="flex flex-row items-center gap-1 font-sans">
+                <MapPin size={16} color="#CA251B" />
+                <Text allowFontScaling={false} className="text-sm text-gray-700">
+                  {restaurant.type}
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+
+        <View className="mb-4 mt-4 rounded-lg bg-gray-100">
+          <View className="p-3 px-4">
+            <Text allowFontScaling={false} className="mb-1 font-semibold text-[#17213A]">
+              Restaurant Info
+            </Text>
+            {restaurant.description ? (
+              <Text allowFontScaling={false} className="text-sm text-[#17213A]">
+                {restaurant.description}
+              </Text>
+            ) : null}
+            {renderHighlights()}
+            <View className="ml-2 mt-2 flex flex-row items-center text-[#17213A]/40">
+              <MapPin size={20} />
+              <Text allowFontScaling={false} className="ml-2 text-[#17213A]">
+                {restaurant.address}
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        {renderQuickFilters()}
+        {renderTopSales()}
+        {renderCategories()}
+
+        <View style={{ height: cartVisible ? 140 : 60 }} />
+      </View>
+    );
+  };
 
   const customHeader = (
     <View style={{ width: '100%', height: '100%' }}>
-      {/* Background image */}
-      <Image
-        source={require('../../assets/TEST.png')}
-        style={StyleSheet.absoluteFillObject} // fills parent
-        contentFit="cover"
-      />
+      <Image source={resolveImageSource(restaurant?.imageUrl)} style={StyleSheet.absoluteFillObject} contentFit="cover" />
 
-      {/* Foreground row */}
       <View
         style={{
-          paddingTop: 0 + insets.top,
+          paddingTop: insets.top,
           flex: 1,
           paddingHorizontal: 16,
           flexDirection: 'row',
@@ -281,7 +416,7 @@ export default function RestaurantDetails() {
         <ArrowLeft size={20} color="#CA251B" />
       </TouchableOpacity>
       <Text allowFontScaling={false} className="flex-1 text-center text-lg font-bold text-gray-800">
-        Di Napoli
+        {restaurant?.name ?? 'Restaurant'}
       </Text>
       <TouchableOpacity className="p-2">
         <Heart size={20} color="#CA251B" />
@@ -292,32 +427,30 @@ export default function RestaurantDetails() {
   return (
     <View className="flex-1">
       <MainLayout
-        showHeader={true}
-        showFooter={true}
+        showHeader
+        showFooter
         customHeader={customHeader}
         collapsedHeader={collapsedHeader}
-        mainContent={mainContent}
+        mainContent={mainContent()}
       />
 
       {cartVisible && cartTotal.count > 0 && !isModalVisible && (
-        <FixedOrderBar
-          total={cartTotal.price}
-          onSeeCart={handleSeeCart}
-          style={{ bottom: 60 + insets.bottom }}
-        />
+        <FixedOrderBar total={cartTotal.price} onSeeCart={handleSeeCart} style={{ bottom: 60 + insets.bottom }} />
       )}
 
-      {isModalVisible && (
+      {isModalVisible && selectedMenuItem && (
         <>
           <TouchableOpacity
             activeOpacity={1}
             onPress={() => handleUpdateCartAndClose({ quantity: 0, total: 0 })}
             className="absolute inset-0 bg-black/50"
           />
-          <Animated.View
-            className="absolute bottom-0 left-0 right-0 overflow-hidden rounded-t-3xl bg-white"
-            style={[{ height: modalHeight }, animatedStyle]}>
-            {modalContent}
+          <Animated.View className="absolute bottom-0 left-0 right-0 overflow-hidden rounded-t-3xl bg-white" style={[{ height: modalHeight }, animatedStyle]}>
+            <MenuDetail
+              menuItem={selectedMenuItem}
+              handleAddItem={handleUpdateCartAndClose}
+              onClose={() => handleUpdateCartAndClose({ quantity: 0, total: 0 })}
+            />
           </Animated.View>
         </>
       )}


### PR DESCRIPTION
## Summary
- add restaurant details response interfaces and API client helper
- fetch restaurant data in the details screen and render quick filters, top sales, and categories dynamically
- power the menu detail modal with API-driven option groups and extras

## Testing
- npm run lint *(fails: unresolved `@env` alias already present in project)*

------
https://chatgpt.com/codex/tasks/task_b_68df96a9e614832c9f28a49557d9a326