### PR TITLE
Integrate checkout page with order API

### DIFF
--- a/src/api/orders.ts
+++ b/src/api/orders.ts
@@ -1,0 +1,9 @@
+import client from './client';
+import type { CreateOrderResponse, OrderRequest } from '~/interfaces/Order';
+
+export const createOrder = async (payload: OrderRequest) => {
+  const { data } = await client.post<CreateOrderResponse>('/orders/create', payload);
+  return data;
+};
+
+export type { CreateOrderResponse, OrderRequest };

--- a/src/interfaces/Order/index.ts
+++ b/src/interfaces/Order/index.ts
@@ -1,0 +1,97 @@
+export type OrderStatus =
+  | 'PENDING'
+  | 'CONFIRMED'
+  | 'PREPARING'
+  | 'READY_FOR_PICKUP'
+  | 'IN_TRANSIT'
+  | 'DELIVERED'
+  | 'CANCELLED'
+  | string;
+
+export type MonetaryAmount = number | string;
+
+export interface OrderExtraSummary {
+  id: number;
+  name: string;
+  price: MonetaryAmount;
+}
+
+export interface OrderedItemSummary {
+  menuItemId: number;
+  name: string;
+  quantity: number;
+  unitPrice: MonetaryAmount;
+  extrasPrice: MonetaryAmount;
+  lineTotal: MonetaryAmount;
+  extras?: OrderExtraSummary[];
+  specialInstructions?: string | null;
+}
+
+export interface LocationDto {
+  lat: number;
+  lng: number;
+}
+
+export interface OrderItemRequest {
+  menuItemId: number;
+  quantity: number;
+  specialInstructions?: string | null;
+  extraIds?: number[];
+}
+
+export interface OrderRequest {
+  deliveryAddress: string;
+  items: OrderItemRequest[];
+  location: LocationDto;
+  paymentMethod: string;
+  restaurantId: number;
+  userId?: number;
+  savedAddressId?: string;
+}
+
+export interface RestaurantSummaryResponse {
+  id: number;
+  name: string;
+  imageUrl?: string | null;
+}
+
+export interface SavedAddressSummaryDto {
+  id?: string;
+  label?: string | null;
+  formattedAddress?: string;
+  type?: string | null;
+  [key: string]: unknown;
+}
+
+export interface DeliverySummaryResponse {
+  address: string;
+  location: LocationDto;
+  savedAddress?: SavedAddressSummaryDto | null;
+}
+
+export interface PaymentSummaryResponse {
+  method: string;
+  subtotal: MonetaryAmount;
+  extrasTotal: MonetaryAmount;
+  total: MonetaryAmount;
+}
+
+export interface OrderWorkflowStepDto {
+  step?: string;
+  label?: string;
+  description?: string | null;
+  status?: string;
+  completed?: boolean;
+  completedAt?: string | null;
+  [key: string]: unknown;
+}
+
+export interface CreateOrderResponse {
+  orderId: number;
+  status: OrderStatus;
+  restaurant: RestaurantSummaryResponse;
+  delivery: DeliverySummaryResponse;
+  payment: PaymentSummaryResponse;
+  items: OrderedItemSummary[];
+  workflow?: OrderWorkflowStepDto[];
+}

--- a/src/screens/CheckoutOrder.tsx
+++ b/src/screens/CheckoutOrder.tsx
@@ -1,22 +1,78 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
-  View,
-  Text,
-  TouchableOpacity,
-  ScrollView,
-  TextInput,
-  StyleSheet,
-  Modal,
+  ActivityIndicator,
+  Alert,
+  Animated,
   GestureResponderEvent,
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
 } from 'react-native';
-import { useNavigation, useRoute, NavigationProp, ParamListBase, RouteProp } from '@react-navigation/native';
-import { ArrowLeft, ChevronDown, CreditCard, TicketPercent, MapPin, PenSquare, Wallet, X } from 'lucide-react-native';
+import {
+  NavigationProp,
+  ParamListBase,
+  RouteProp,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native';
+import {
+  ArrowLeft,
+  CheckCircle2,
+  ChevronDown,
+  CreditCard,
+  MapPin,
+  PartyPopper,
+  PenSquare,
+  TicketPercent,
+  Wallet,
+  X,
+} from 'lucide-react-native';
 import MapView, { Marker } from 'react-native-maps';
+import { isAxiosError } from 'axios';
+
+import { useCart } from '~/context/CartContext';
+import useSelectedAddress from '~/hooks/useSelectedAddress';
+import useAuth from '~/hooks/useAuth';
+import { createOrder } from '~/api/orders';
+import type { CreateOrderResponse, MonetaryAmount } from '~/interfaces/Order';
 
 const sectionTitleColor = '#17213A';
 const accentColor = '#CA251B';
 const borderColor = '#E8E9EC';
+
+const formatCurrency = (value: number) => `${value.toFixed(3)} dt`;
+
+const parseMonetaryAmount = (value: MonetaryAmount | null | undefined) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.replace(',', '.');
+    const parsed = Number(normalized);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return 0;
+};
+
+const formatServerMoney = (value: MonetaryAmount | null | undefined) => formatCurrency(parseMonetaryAmount(value));
+
+const formatStatusLabel = (status?: string | null) => {
+  if (!status) {
+    return 'Pending';
+  }
+
+  const normalized = status.replace(/_/g, ' ');
+  return normalized.replace(/\b\w/g, (char) => char.toUpperCase());
+};
 
 interface AccordionProps {
   title: string;
@@ -41,19 +97,32 @@ const Accordion: React.FC<AccordionProps> = ({ title, expanded, onToggle, childr
         style={{ transform: [{ rotate: expanded ? '180deg' : '0deg' }] }}
       />
     </TouchableOpacity>
-    {expanded && (
+    {expanded ? (
       <View className="border-t px-5 pb-5 pt-4" style={{ borderColor }}>
         {children}
       </View>
-    )}
+    ) : null}
   </View>
 );
+
+type PaymentMethod = 'CARD' | 'CASH';
+
+type PaymentOption = {
+  id: PaymentMethod;
+  label: string;
+  Icon: React.ComponentType<{ size?: number; color?: string }>;
+};
+
+const PAYMENT_OPTIONS: PaymentOption[] = [
+  { id: 'CARD', label: 'Add new Credit Card', Icon: CreditCard },
+  { id: 'CASH', label: 'Pay by Cash', Icon: Wallet },
+];
 
 const PaymentModal: React.FC<{
   visible: boolean;
   onClose: () => void;
-  onSelect: (method: string) => void;
-  selected: string;
+  onSelect: (method: PaymentMethod) => void;
+  selected: PaymentMethod | null;
 }> = ({ visible, onClose, onSelect, selected }) => (
   <Modal
     animationType="fade"
@@ -71,47 +140,40 @@ const PaymentModal: React.FC<{
         <Text allowFontScaling={false} className="text-center text-lg font-semibold" style={{ color: sectionTitleColor }}>
           Payment method
         </Text>
-        <TouchableOpacity
-          activeOpacity={0.8}
-          onPress={() => onSelect('Add new Credit Card')}
-          className="mt-6 flex-row items-center justify-between rounded-2xl border px-4 py-4"
-          style={{
-            borderColor: selected === 'Add new Credit Card' ? accentColor : '#EFEFF1',
-            backgroundColor: selected === 'Add new Credit Card' ? '#FFF5F4' : 'white',
-          }}
-        >
-          <View className="flex-row items-center">
-            <CreditCard size={22} color={accentColor} />
-            <Text allowFontScaling={false} className="ml-3 text-base font-semibold" style={{ color: sectionTitleColor }}>
-              Add new Credit Card
-            </Text>
-          </View>
-          <ChevronDown size={20} color={sectionTitleColor} style={{ transform: [{ rotate: '-90deg' }] }} />
-        </TouchableOpacity>
-        <TouchableOpacity
-          activeOpacity={0.8}
-          onPress={() => onSelect('Pay by Cash')}
-          className="mt-4 flex-row items-center justify-between rounded-2xl border px-4 py-4"
-          style={{
-            borderColor: selected === 'Pay by Cash' ? accentColor : '#EFEFF1',
-            backgroundColor: selected === 'Pay by Cash' ? '#FFF5F4' : 'white',
-          }}
-        >
-          <View className="flex-row items-center">
-            <Wallet size={22} color={accentColor} />
-            <Text allowFontScaling={false} className="ml-3 text-base font-semibold" style={{ color: sectionTitleColor }}>
-              Pay by Cash
-            </Text>
-          </View>
-          <View
-            className="h-5 w-5 items-center justify-center rounded-full border"
-            style={{ borderColor: accentColor, backgroundColor: 'white' }}
-          >
-            {selected === 'Pay by Cash' && (
-              <View className="h-3.5 w-3.5 rounded-full" style={{ backgroundColor: accentColor }} />
-            )}
-          </View>
-        </TouchableOpacity>
+        {PAYMENT_OPTIONS.map((option, index) => {
+          const isSelected = selected === option.id;
+          return (
+            <TouchableOpacity
+              key={option.id}
+              activeOpacity={0.8}
+              onPress={() => onSelect(option.id)}
+              className={`${index === 0 ? 'mt-6' : 'mt-4'} flex-row items-center justify-between rounded-2xl border px-4 py-4`}
+              style={{
+                borderColor: isSelected ? accentColor : '#EFEFF1',
+                backgroundColor: isSelected ? '#FFF5F4' : 'white',
+              }}
+            >
+              <View className="flex-row items-center">
+                <option.Icon size={22} color={accentColor} />
+                <Text allowFontScaling={false} className="ml-3 text-base font-semibold" style={{ color: sectionTitleColor }}>
+                  {option.label}
+                </Text>
+              </View>
+              {option.id === 'CARD' ? (
+                <ChevronDown size={20} color={sectionTitleColor} style={{ transform: [{ rotate: '-90deg' }] }} />
+              ) : (
+                <View
+                  className="h-5 w-5 items-center justify-center rounded-full border"
+                  style={{ borderColor: accentColor, backgroundColor: 'white' }}
+                >
+                  {isSelected ? (
+                    <View className="h-3.5 w-3.5 rounded-full" style={{ backgroundColor: accentColor }} />
+                  ) : null}
+                </View>
+              )}
+            </TouchableOpacity>
+          );
+        })}
       </View>
     </View>
   </Modal>
@@ -125,16 +187,274 @@ type CheckoutRouteParams = {
 
 type CheckoutRoute = RouteProp<{ CheckoutOrder: CheckoutRouteParams }, 'CheckoutOrder'>;
 
+interface OrderConfirmationOverlayProps {
+  visible: boolean;
+  response: CreateOrderResponse | null;
+  onClose: () => void;
+  onViewOrder: () => void;
+}
+
+const OrderConfirmationOverlay: React.FC<OrderConfirmationOverlayProps> = ({ visible, response, onClose, onViewOrder }) => {
+  const cardScale = useRef(new Animated.Value(0.9)).current;
+  const cardOpacity = useRef(new Animated.Value(0)).current;
+  const iconScale = useRef(new Animated.Value(0)).current;
+  const ripple = useRef(new Animated.Value(0)).current;
+  const loopRef = useRef<Animated.CompositeAnimation | null>(null);
+
+  useEffect(() => {
+    if (!visible) {
+      loopRef.current?.stop();
+      loopRef.current = null;
+      return;
+    }
+
+    cardScale.setValue(0.9);
+    cardOpacity.setValue(0);
+    iconScale.setValue(0);
+    ripple.setValue(0);
+
+    Animated.parallel([
+      Animated.timing(cardOpacity, {
+        toValue: 1,
+        duration: 220,
+        useNativeDriver: true,
+      }),
+      Animated.spring(cardScale, {
+        toValue: 1,
+        useNativeDriver: true,
+      }),
+      Animated.spring(iconScale, {
+        toValue: 1,
+        tension: 200,
+        friction: 14,
+        useNativeDriver: true,
+      }),
+    ]).start();
+
+    loopRef.current?.stop();
+    loopRef.current = Animated.loop(
+      Animated.sequence([
+        Animated.timing(ripple, {
+          toValue: 1,
+          duration: 1200,
+          useNativeDriver: true,
+        }),
+        Animated.timing(ripple, {
+          toValue: 0,
+          duration: 0,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    loopRef.current.start();
+
+    return () => {
+      loopRef.current?.stop();
+      loopRef.current = null;
+    };
+  }, [visible, cardOpacity, cardScale, iconScale, ripple]);
+
+  const rippleScale = ripple.interpolate({
+    inputRange: [0, 1],
+    outputRange: [1, 1.6],
+  });
+  const rippleOpacity = ripple.interpolate({
+    inputRange: [0, 0.6, 1],
+    outputRange: [0.35, 0.15, 0],
+  });
+  const iconRotation = iconScale.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['-20deg', '0deg'],
+  });
+
+  const items = response?.items ?? [];
+  const displayedItems = items.slice(0, 3);
+  const remainingItemsCount = Math.max(0, items.length - displayedItems.length);
+  const workflowSteps = response?.workflow ?? [];
+  const displayedWorkflow = workflowSteps.slice(0, 3);
+  const statusLabel = formatStatusLabel(response?.status);
+
+  return (
+    <Modal visible={visible} animationType="fade" transparent onRequestClose={onClose}>
+      <View className="flex-1 justify-center bg-[#17213A]/60 px-6">
+        <TouchableOpacity activeOpacity={1} className="absolute inset-0" onPress={onClose} />
+        <Animated.View
+          className="overflow-hidden rounded-3xl bg-white p-6"
+          style={{
+            opacity: cardOpacity,
+            transform: [{ scale: cardScale }],
+          }}
+        >
+          <View className="items-center">
+            <View className="relative mb-4 h-24 w-24 items-center justify-center">
+              <Animated.View
+                className="absolute inset-0 rounded-full"
+                style={{
+                  backgroundColor: '#FDE7E5',
+                  transform: [{ scale: rippleScale }],
+                  opacity: rippleOpacity,
+                }}
+              />
+              <Animated.View style={{ transform: [{ scale: iconScale }, { rotate: iconRotation }] }}>
+                <CheckCircle2 size={64} color={accentColor} />
+              </Animated.View>
+            </View>
+            <View className="flex-row items-center">
+              <PartyPopper size={20} color={accentColor} />
+              <Text allowFontScaling={false} className="ml-2 text-lg font-bold text-[#17213A]">
+                Order confirmed!
+              </Text>
+            </View>
+            <Text allowFontScaling={false} className="mt-2 text-sm text-[#4B5563]">
+              {response
+                ? `#${response.orderId} at ${response.restaurant?.name ?? 'your restaurant'}`
+                : 'We are preparing your delicious meal.'}
+            </Text>
+            <View className="mt-3 rounded-full bg-[#FDE7E5] px-4 py-1">
+              <Text allowFontScaling={false} className="text-xs font-semibold uppercase text-[#CA251B]">
+                {statusLabel}
+              </Text>
+            </View>
+          </View>
+
+          <View className="mt-6 rounded-2xl bg-[#F9FAFB] p-4">
+            <Text allowFontScaling={false} className="text-xs font-semibold uppercase text-[#6B7280]">
+              Order summary
+            </Text>
+            <View className="mt-3 flex-row items-center justify-between">
+              <Text allowFontScaling={false} className="text-sm font-semibold text-[#17213A]">
+                Total
+              </Text>
+              <Text allowFontScaling={false} className="text-base font-bold text-[#CA251B]">
+                {formatServerMoney(response?.payment?.total)}
+              </Text>
+            </View>
+            <View className="mt-3 flex-row items-center justify-between">
+              <Text allowFontScaling={false} className="text-xs text-[#6B7280]">
+                Payment
+              </Text>
+              <Text allowFontScaling={false} className="text-xs font-semibold text-[#17213A]">
+                {response?.payment?.method ?? 'Selected method'}
+              </Text>
+            </View>
+          </View>
+
+          {displayedItems.length ? (
+            <View className="mt-4 rounded-2xl border border-dashed border-[#F0F1F3] p-4">
+              <Text allowFontScaling={false} className="text-xs font-semibold uppercase text-[#6B7280]">
+                Items
+              </Text>
+              {displayedItems.map((item) => (
+                <View
+                  key={`${item.menuItemId}-${item.name}`}
+                  className="mt-3 flex-row items-start justify-between"
+                >
+                  <View className="flex-1 pr-4">
+                    <Text allowFontScaling={false} className="text-sm font-semibold text-[#17213A]">
+                      {item.quantity} × {item.name}
+                    </Text>
+                    {item.extras?.length ? (
+                      <Text allowFontScaling={false} className="mt-1 text-xs text-[#6B7280]">
+                        Extras: {item.extras.map((extra) => extra.name).join(', ')}
+                      </Text>
+                    ) : null}
+                  </View>
+                  <Text allowFontScaling={false} className="text-sm font-semibold text-[#17213A]">
+                    {formatServerMoney(item.lineTotal)}
+                  </Text>
+                </View>
+              ))}
+              {remainingItemsCount > 0 ? (
+                <Text allowFontScaling={false} className="mt-3 text-xs text-[#6B7280]">
+                  + {remainingItemsCount} more {remainingItemsCount === 1 ? 'item' : 'items'}
+                </Text>
+              ) : null}
+            </View>
+          ) : null}
+
+          {displayedWorkflow.length ? (
+            <View className="mt-4 rounded-2xl border border-[#F0F1F3] p-4">
+              <Text allowFontScaling={false} className="text-xs font-semibold uppercase text-[#6B7280]">
+                Next steps
+              </Text>
+              {displayedWorkflow.map((step, index) => {
+                const stepLabel =
+                  (typeof step.label === 'string' && step.label) ||
+                  (typeof step.step === 'string' && step.step) ||
+                  `Step ${index + 1}`;
+                const stepStatus = typeof step.status === 'string' ? formatStatusLabel(step.status) : null;
+                const completed = Boolean(step.completed);
+
+                return (
+                  <View key={`${stepLabel}-${index}`} className="mt-3 flex-row items-center justify-between">
+                    <View className="flex-1 pr-4">
+                      <Text allowFontScaling={false} className="text-sm font-semibold text-[#17213A]">
+                        {stepLabel}
+                      </Text>
+                      {stepStatus ? (
+                        <Text allowFontScaling={false} className="text-xs text-[#6B7280]">
+                          {stepStatus}
+                        </Text>
+                      ) : null}
+                    </View>
+                    {completed ? (
+                      <CheckCircle2 size={20} color={accentColor} />
+                    ) : (
+                      <View
+                        className="h-2.5 w-2.5 rounded-full"
+                        style={{ backgroundColor: `${accentColor}33` }}
+                      />
+                    )}
+                  </View>
+                );
+              })}
+            </View>
+          ) : null}
+
+          <View className="mt-6 flex-row gap-3">
+            <TouchableOpacity
+              activeOpacity={0.85}
+              onPress={onViewOrder}
+              className="flex-1 rounded-full border border-[#CA251B] px-4 py-3"
+            >
+              <Text allowFontScaling={false} className="text-center text-sm font-semibold text-[#CA251B]">
+                Track order
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              activeOpacity={0.9}
+              onPress={onClose}
+              className="flex-1 rounded-full bg-[#CA251B] px-4 py-3"
+            >
+              <Text allowFontScaling={false} className="text-center text-sm font-semibold text-white">
+                Great!
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+};
+
 const CheckoutOrder: React.FC = () => {
   const navigation = useNavigation<NavigationProp<ParamListBase>>();
   const route = useRoute<CheckoutRoute>();
+  const { items, restaurant, itemCount, subtotal, clearCart } = useCart();
+  const { selectedAddress } = useSelectedAddress();
+  const { user } = useAuth();
+  const [itemsExpanded, setItemsExpanded] = useState(true);
   const [allergiesExpanded, setAllergiesExpanded] = useState(false);
   const [commentExpanded, setCommentExpanded] = useState(false);
   const [allergies, setAllergies] = useState('');
   const [comment, setComment] = useState('');
-  const [paymentMethod, setPaymentMethod] = useState('Select Payment method');
+  const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<PaymentMethod | null>(null);
   const [isPaymentModalVisible, setIsPaymentModalVisible] = useState(false);
   const [appliedCoupon, setAppliedCoupon] = useState<{ code: string; discount: number } | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
+  const [orderResponse, setOrderResponse] = useState<CreateOrderResponse | null>(null);
+  const [confirmationVisible, setConfirmationVisible] = useState(false);
 
   useEffect(() => {
     const params = route.params;
@@ -144,22 +464,218 @@ const CheckoutOrder: React.FC = () => {
     }
   }, [route.params, navigation]);
 
-  const totalProducts = 4;
-  const restaurantName = 'Di Napoli';
-  const subtotal = 48;
-  const fees = 4.5;
-  const service = 2.5;
+  const hasItems = items.length > 0;
+  const restaurantName = restaurant?.name ?? 'Restaurant';
+
+  const extrasTotal = useMemo(
+    () => items.reduce((sum, item) => sum + item.extrasTotal * item.quantity, 0),
+    [items],
+  );
+  const baseSubtotal = useMemo(
+    () => items.reduce((sum, item) => sum + item.basePrice * item.quantity, 0),
+    [items],
+  );
+  const deliveryFee = useMemo(() => (hasItems ? Math.max(2.5, subtotal * 0.08) : 0), [hasItems, subtotal]);
+  const serviceFee = useMemo(() => (hasItems ? Math.max(1.5, subtotal * 0.05) : 0), [hasItems, subtotal]);
   const discountValue = appliedCoupon?.discount ?? 0;
-  const total = useMemo(() => subtotal + fees + service - discountValue, [subtotal, fees, service, discountValue]);
+  const total = useMemo(
+    () => Math.max(subtotal + deliveryFee + serviceFee - discountValue, 0),
+    [subtotal, deliveryFee, serviceFee, discountValue],
+  );
 
-  const handlePaymentSelection = (method: string) => {
-    setPaymentMethod(method);
+  const combinedInstructions = useMemo(() => {
+    const trimmedComment = comment.trim();
+    const trimmedAllergies = allergies.trim();
+    const parts: string[] = [];
+
+    if (trimmedComment.length) {
+      parts.push(trimmedComment);
+    }
+
+    if (trimmedAllergies.length) {
+      parts.push(`Allergies: ${trimmedAllergies}`);
+    }
+
+    if (!parts.length) {
+      return undefined;
+    }
+
+    return parts.join(' | ');
+  }, [allergies, comment]);
+
+  const paymentMethodLabel = useMemo(() => {
+    if (!selectedPaymentMethod) {
+      return 'Select payment method';
+    }
+
+    const option = PAYMENT_OPTIONS.find((candidate) => candidate.id === selectedPaymentMethod);
+    return option?.label ?? 'Select payment method';
+  }, [selectedPaymentMethod]);
+
+  const SelectedPaymentIcon = useMemo(() => {
+    if (!selectedPaymentMethod) {
+      return CreditCard;
+    }
+    const option = PAYMENT_OPTIONS.find((candidate) => candidate.id === selectedPaymentMethod);
+    return option?.Icon ?? CreditCard;
+  }, [selectedPaymentMethod]);
+
+  const deliveryRegion = useMemo(() => {
+    if (!selectedAddress?.coordinates) {
+      return null;
+    }
+
+    const latCandidate = Number(selectedAddress.coordinates.latitude);
+    const lngCandidate = Number(selectedAddress.coordinates.longitude);
+
+    if (!Number.isFinite(latCandidate) || !Number.isFinite(lngCandidate)) {
+      return null;
+    }
+
+    return {
+      latitude: latCandidate,
+      longitude: lngCandidate,
+      latitudeDelta: 0.01,
+      longitudeDelta: 0.01,
+    };
+  }, [selectedAddress]);
+
+  const addressDetails = useMemo(() => {
+    if (!selectedAddress) {
+      return null;
+    }
+
+    const candidates = [selectedAddress.directions, selectedAddress.notes, selectedAddress.entranceNotes];
+    const detail = candidates.find(
+      (value): value is string => typeof value === 'string' && value.trim().length > 0,
+    );
+
+    return detail ?? null;
+  }, [selectedAddress]);
+
+  const handlePaymentSelection = useCallback((method: PaymentMethod) => {
+    setSelectedPaymentMethod(method);
     setIsPaymentModalVisible(false);
-  };
+  }, []);
 
-  const handleRemoveCoupon = () => {
+  const handleRemoveCoupon = useCallback(() => {
     setAppliedCoupon(null);
-  };
+  }, []);
+
+  const handleOpenLocationSelection = useCallback(() => {
+    navigation.navigate('LocationSelection');
+  }, [navigation]);
+
+  const handleConfirmOrder = useCallback(async () => {
+    if (!hasItems) {
+      setSubmissionError('Your cart is empty.');
+      return;
+    }
+
+    if (!restaurant?.id) {
+      setSubmissionError('Missing restaurant information.');
+      return;
+    }
+
+    if (!selectedAddress) {
+      setSubmissionError('Please choose a delivery address.');
+      return;
+    }
+
+    const latCandidate = Number(selectedAddress.coordinates?.latitude);
+    const lngCandidate = Number(selectedAddress.coordinates?.longitude);
+
+    if (!Number.isFinite(latCandidate) || !Number.isFinite(lngCandidate)) {
+      setSubmissionError('The selected address is missing coordinates. Please update it and try again.');
+      return;
+    }
+
+    if (!selectedPaymentMethod) {
+      setSubmissionError('Select a payment method to continue.');
+      return;
+    }
+
+    setSubmissionError(null);
+    setIsSubmitting(true);
+
+    try {
+      const numericUserId =
+        typeof user?.id === 'number' ? user.id : Number(user?.id);
+
+      const payload = {
+        deliveryAddress: selectedAddress.formattedAddress,
+        items: items.map((item) => {
+          const extraIds = item.extras.flatMap((group) => group.extras.map((extra) => extra.id));
+          return {
+            menuItemId: item.menuItemId,
+            quantity: item.quantity,
+            specialInstructions: combinedInstructions,
+            extraIds: extraIds.length ? extraIds : undefined,
+          };
+        }),
+        location: {
+          lat: latCandidate,
+          lng: lngCandidate,
+        },
+        paymentMethod: selectedPaymentMethod,
+        restaurantId: restaurant.id,
+        userId: Number.isFinite(numericUserId) ? Number(numericUserId) : undefined,
+        savedAddressId: selectedAddress.id,
+      };
+
+      const response = await createOrder(payload);
+      setOrderResponse(response);
+      setConfirmationVisible(true);
+      clearCart();
+      setAppliedCoupon(null);
+      setComment('');
+      setAllergies('');
+    } catch (error) {
+      console.error('Failed to create order:', error);
+      const message = (() => {
+        if (isAxiosError(error)) {
+          const responseMessage =
+            (typeof error.response?.data === 'object' && error.response?.data && 'message' in error.response.data
+              ? String((error.response?.data as { message?: unknown }).message)
+              : null) ?? error.message;
+          return responseMessage || 'We could not place your order. Please try again.';
+        }
+
+        if (error instanceof Error) {
+          return error.message;
+        }
+
+        return 'We could not place your order. Please try again.';
+      })();
+
+      setSubmissionError(message);
+      Alert.alert('Order failed', message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [
+    hasItems,
+    restaurant?.id,
+    selectedAddress,
+    selectedPaymentMethod,
+    user?.id,
+    items,
+    combinedInstructions,
+    clearCart,
+  ]);
+
+  const handleCloseConfirmation = useCallback(() => {
+    setConfirmationVisible(false);
+    setOrderResponse(null);
+  }, []);
+
+  const handleViewOrder = useCallback(() => {
+    setConfirmationVisible(false);
+    setOrderResponse(null);
+    navigation.navigate('OrderHistory');
+  }, [navigation]);
+
+  const canSubmit = hasItems && Boolean(selectedAddress) && Boolean(selectedPaymentMethod) && !isSubmitting;
 
   return (
     <SafeAreaView className="flex-1 bg-white">
@@ -173,23 +689,63 @@ const CheckoutOrder: React.FC = () => {
         <View className="w-10" />
       </View>
 
-      <ScrollView
-        contentContainerStyle={{ paddingBottom: 32 }}
-        className="flex-1"
-      >
+      <ScrollView contentContainerStyle={{ paddingBottom: 32 }} className="flex-1">
         <View className="px-4">
           <View className="rounded-3xl bg-white">
-            <TouchableOpacity activeOpacity={0.8} className="flex-row items-center justify-between rounded-3xl border border-[#F0F1F3] px-5 py-4">
+            <TouchableOpacity
+              activeOpacity={0.8}
+              onPress={() => setItemsExpanded((prev) => !prev)}
+              className="flex-row items-center justify-between rounded-3xl border border-[#F0F1F3] px-5 py-4"
+            >
               <View>
                 <Text allowFontScaling={false} className="text-sm font-semibold" style={{ color: accentColor }}>
-                  {totalProducts} Product from
+                  {itemCount} {itemCount === 1 ? 'Product' : 'Products'} from
                 </Text>
                 <Text allowFontScaling={false} className="text-lg font-bold" style={{ color: accentColor }}>
                   {restaurantName}
                 </Text>
+                <Text allowFontScaling={false} className="mt-1 text-sm font-semibold text-[#17213A]">
+                  {formatCurrency(subtotal)}
+                </Text>
               </View>
-              <ChevronDown size={20} color={accentColor} />
+              <ChevronDown
+                size={20}
+                color={accentColor}
+                style={{ transform: [{ rotate: itemsExpanded ? '180deg' : '0deg' }] }}
+              />
             </TouchableOpacity>
+            {itemsExpanded ? (
+              <View className="border-t" style={{ borderColor }}>
+                {hasItems ? (
+                  items.map((item) => (
+                    <View key={item.id} className="flex-row items-start justify-between px-5 py-4">
+                      <View className="flex-1 pr-3">
+                        <Text allowFontScaling={false} className="text-sm font-semibold text-[#17213A]">
+                          {item.quantity} × {item.name}
+                        </Text>
+                        {item.extras.length ? (
+                          <Text allowFontScaling={false} className="mt-1 text-xs text-[#6B7280]">
+                            Extras:{' '}
+                            {item.extras
+                              .flatMap((group) => group.extras.map((extra) => extra.name))
+                              .join(', ')}
+                          </Text>
+                        ) : null}
+                      </View>
+                      <Text allowFontScaling={false} className="text-sm font-semibold text-[#17213A]">
+                        {formatCurrency(item.totalPrice)}
+                      </Text>
+                    </View>
+                  ))
+                ) : (
+                  <View className="px-5 py-4">
+                    <Text allowFontScaling={false} className="text-sm text-[#6B7280]">
+                      Your cart is empty.
+                    </Text>
+                  </View>
+                )}
+              </View>
+            ) : null}
           </View>
 
           <Accordion
@@ -227,38 +783,80 @@ const CheckoutOrder: React.FC = () => {
           </Accordion>
 
           <View className="mt-6">
-            <Text allowFontScaling={false} className="text-base font-bold" style={{ color: sectionTitleColor }}>
-              Delivery Address
-            </Text>
-            <View className="mt-3 overflow-hidden rounded-3xl border" style={{ borderColor }}>
-              <View style={styles.mapWrapper}>
-                <MapView
-                  style={StyleSheet.absoluteFill}
-                  initialRegion={{
-                    latitude: 36.8625,
-                    longitude: 10.1956,
-                    latitudeDelta: 0.01,
-                    longitudeDelta: 0.01,
-                  }}
-                  scrollEnabled={false}
-                  zoomEnabled={false}
-                  pitchEnabled={false}
-                  rotateEnabled={false}
-                >
-                  <Marker
-                    coordinate={{ latitude: 36.8625, longitude: 10.1956 }}
-                    title="Delivery Address"
-                    description="Rue Mustapha Abdessalem, Ariana 2091"
-                  />
-                </MapView>
-              </View>
-              <View className="flex-row items-start gap-3 bg-white px-4 py-4">
-                <MapPin size={18} color={accentColor} />
-                <Text allowFontScaling={false} className="flex-1 text-sm text-[#4B5563]">
-                  Rue Mustapha Abdessalem, Ariana 2091
+            <View className="flex-row items-center justify-between">
+              <Text allowFontScaling={false} className="text-base font-bold" style={{ color: sectionTitleColor }}>
+                Delivery Address
+              </Text>
+              <TouchableOpacity
+                activeOpacity={0.8}
+                onPress={handleOpenLocationSelection}
+                className="rounded-full bg-[#FDE7E5] px-3 py-1"
+              >
+                <Text allowFontScaling={false} className="text-xs font-semibold text-[#CA251B]">
+                  Change
                 </Text>
-              </View>
+              </TouchableOpacity>
             </View>
+            {selectedAddress ? (
+              <View className="mt-3 overflow-hidden rounded-3xl border" style={{ borderColor }}>
+                <View style={styles.mapWrapper}>
+                  {deliveryRegion ? (
+                    <MapView
+                      key={selectedAddress.id}
+                      style={StyleSheet.absoluteFill}
+                      initialRegion={deliveryRegion}
+                      scrollEnabled={false}
+                      zoomEnabled={false}
+                      pitchEnabled={false}
+                      rotateEnabled={false}
+                    >
+                      <Marker
+                        coordinate={deliveryRegion}
+                        title="Delivery Address"
+                        description={selectedAddress.formattedAddress}
+                      />
+                    </MapView>
+                  ) : (
+                    <View className="flex-1 items-center justify-center bg-[#FDE7E5]">
+                      <MapPin size={24} color={accentColor} />
+                      <Text allowFontScaling={false} className="mt-2 text-xs font-semibold text-[#CA251B]">
+                        Set a precise location to preview it here
+                      </Text>
+                    </View>
+                  )}
+                </View>
+                <View className="flex-row items-start gap-3 bg-white px-4 py-4">
+                  <MapPin size={18} color={accentColor} />
+                  <View className="flex-1">
+                    <Text allowFontScaling={false} className="text-sm font-semibold text-[#17213A]">
+                      {selectedAddress.label?.trim()?.length ? selectedAddress.label : 'Saved address'}
+                    </Text>
+                    <Text allowFontScaling={false} className="mt-1 text-sm text-[#4B5563]">
+                      {selectedAddress.formattedAddress}
+                    </Text>
+                    {addressDetails ? (
+                      <Text allowFontScaling={false} className="mt-1 text-xs text-[#6B7280]">
+                        {addressDetails}
+                      </Text>
+                    ) : null}
+                  </View>
+                </View>
+              </View>
+            ) : (
+              <TouchableOpacity
+                activeOpacity={0.8}
+                onPress={handleOpenLocationSelection}
+                className="mt-3 flex-row items-center justify-between rounded-3xl border border-dashed border-[#F0F1F3] bg-white px-5 py-4"
+              >
+                <View className="flex-1 flex-row items-center">
+                  <MapPin size={22} color={accentColor} />
+                  <Text allowFontScaling={false} className="ml-3 flex-1 text-base font-semibold" style={{ color: sectionTitleColor }}>
+                    Choose where to deliver your order
+                  </Text>
+                </View>
+                <ChevronDown size={20} color={sectionTitleColor} style={{ transform: [{ rotate: '-90deg' }] }} />
+              </TouchableOpacity>
+            )}
           </View>
 
           <View className="mt-6">
@@ -271,9 +869,9 @@ const CheckoutOrder: React.FC = () => {
               className="mt-3 flex-row items-center justify-between rounded-3xl border border-[#F0F1F3] bg-white px-5 py-4"
             >
               <View className="flex-row items-center">
-                <CreditCard size={22} color={accentColor} />
+                <SelectedPaymentIcon size={22} color={accentColor} />
                 <Text allowFontScaling={false} className="ml-3 text-base font-semibold" style={{ color: sectionTitleColor }}>
-                  {paymentMethod}
+                  {paymentMethodLabel}
                 </Text>
               </View>
               <ChevronDown size={20} color={sectionTitleColor} />
@@ -295,11 +893,11 @@ const CheckoutOrder: React.FC = () => {
                 <Text allowFontScaling={false} className="text-base font-semibold" style={{ color: sectionTitleColor }}>
                   {appliedCoupon ? 'Coupon applied' : 'Add Coupon code'}
                 </Text>
-                {appliedCoupon && (
+                {appliedCoupon ? (
                   <Text allowFontScaling={false} className="mt-1 text-sm text-[#6B7280]">
-                    {appliedCoupon.code} −{appliedCoupon.discount.toFixed(2)} dt
+                    {appliedCoupon.code} −{formatCurrency(discountValue)}
                   </Text>
-                )}
+                ) : null}
               </View>
             </View>
             {appliedCoupon ? (
@@ -319,32 +917,54 @@ const CheckoutOrder: React.FC = () => {
 
           <View className="mt-6 rounded-3xl border border-[#F0F1F3] bg-white p-5">
             <View className="flex-row items-center justify-between">
-              <Text allowFontScaling={false} className="text-sm text-[#6B7280]">Subtotal</Text>
-              <Text allowFontScaling={false} className="text-sm font-semibold text-[#4B5563]">{subtotal.toFixed(2)} dt</Text>
+              <Text allowFontScaling={false} className="text-sm text-[#6B7280]">
+                Items
+              </Text>
+              <Text allowFontScaling={false} className="text-sm font-semibold text-[#4B5563]">
+                {formatCurrency(baseSubtotal)}
+              </Text>
             </View>
             <View className="mt-3 flex-row items-center justify-between">
-              <Text allowFontScaling={false} className="text-sm text-[#6B7280]">Fees</Text>
-              <Text allowFontScaling={false} className="text-sm font-semibold text-[#4B5563]">{fees.toFixed(2)} dt</Text>
+              <Text allowFontScaling={false} className="text-sm text-[#6B7280]">
+                Extras
+              </Text>
+              <Text allowFontScaling={false} className="text-sm font-semibold text-[#4B5563]">
+                {formatCurrency(extrasTotal)}
+              </Text>
             </View>
             <View className="mt-3 flex-row items-center justify-between">
-              <Text allowFontScaling={false} className="text-sm text-[#6B7280]">Service</Text>
-              <Text allowFontScaling={false} className="text-sm font-semibold text-[#4B5563]">{service.toFixed(2)} dt</Text>
+              <Text allowFontScaling={false} className="text-sm text-[#6B7280]">
+                Delivery
+              </Text>
+              <Text allowFontScaling={false} className="text-sm font-semibold text-[#4B5563]">
+                {formatCurrency(deliveryFee)}
+              </Text>
             </View>
-            {appliedCoupon && (
+            <View className="mt-3 flex-row items-center justify-between">
+              <Text allowFontScaling={false} className="text-sm text-[#6B7280]">
+                Service
+              </Text>
+              <Text allowFontScaling={false} className="text-sm font-semibold text-[#4B5563]">
+                {formatCurrency(serviceFee)}
+              </Text>
+            </View>
+            {appliedCoupon ? (
               <View className="mt-3 flex-row items-center justify-between">
-                <Text allowFontScaling={false} className="text-sm text-[#6B7280]">Coupon ({appliedCoupon.code})</Text>
-                <Text allowFontScaling={false} className="text-sm font-semibold text-[#4B5563]">-
-                  {appliedCoupon.discount.toFixed(2)} dt
+                <Text allowFontScaling={false} className="text-sm text-[#6B7280]">
+                  Coupon ({appliedCoupon.code})
+                </Text>
+                <Text allowFontScaling={false} className="text-sm font-semibold text-[#CA251B]">
+                  −{formatCurrency(discountValue)}
                 </Text>
               </View>
-            )}
+            ) : null}
             <View className="mt-4 border-t border-dashed pt-4" style={{ borderColor }}>
               <View className="flex-row items-center justify-between">
                 <Text allowFontScaling={false} className="text-lg font-bold" style={{ color: sectionTitleColor }}>
                   Total
                 </Text>
                 <Text allowFontScaling={false} className="text-lg font-bold" style={{ color: accentColor }}>
-                  {total.toFixed(2)} dt
+                  {formatCurrency(total)}
                 </Text>
               </View>
             </View>
@@ -353,13 +973,27 @@ const CheckoutOrder: React.FC = () => {
       </ScrollView>
 
       <View className="px-4 pb-6">
+        {submissionError ? (
+          <Text allowFontScaling={false} className="mb-3 text-center text-sm text-[#CA251B]">
+            {submissionError}
+          </Text>
+        ) : null}
         <TouchableOpacity
           activeOpacity={0.9}
-          className="rounded-full bg-[#CA251B] px-6 py-4"
+          className={`rounded-full px-6 py-4 ${canSubmit ? 'bg-[#CA251B]' : 'bg-[#F1F2F4]'}`}
+          disabled={!canSubmit}
+          onPress={handleConfirmOrder}
         >
-          <Text allowFontScaling={false} className="text-center text-base font-semibold text-white">
-            Confirm and pay to order
-          </Text>
+          {isSubmitting ? (
+            <ActivityIndicator color={canSubmit ? '#FFFFFF' : '#9CA3AF'} />
+          ) : (
+            <Text
+              allowFontScaling={false}
+              className={`text-center text-base font-semibold ${canSubmit ? 'text-white' : 'text-[#9CA3AF]'}`}
+            >
+              Confirm and pay to order
+            </Text>
+          )}
         </TouchableOpacity>
       </View>
 
@@ -367,7 +1001,14 @@ const CheckoutOrder: React.FC = () => {
         visible={isPaymentModalVisible}
         onClose={() => setIsPaymentModalVisible(false)}
         onSelect={handlePaymentSelection}
-        selected={paymentMethod}
+        selected={selectedPaymentMethod}
+      />
+
+      <OrderConfirmationOverlay
+        visible={confirmationVisible}
+        response={orderResponse}
+        onClose={handleCloseConfirmation}
+        onViewOrder={handleViewOrder}
       />
     </SafeAreaView>
   );


### PR DESCRIPTION
## Summary
- wire the checkout order screen to the cart and saved address contexts so totals, address details, and payment selection come from live data
- add an orders API client plus supporting TypeScript types to submit the create order payload
- display an animated confirmation overlay with order details after a successful checkout and clear the cart

## Testing
- npm run lint *(fails: existing @env module resolution errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68dfabb3a2a0832c9a30ff775f152fd4