### PR TITLE
Add animated order tracking screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -22,6 +22,7 @@ import Cart from '~/screens/Cart';
 import CheckoutOrder from '~/screens/CheckoutOrder';
 import CouponCode from '~/screens/CouponCode';
 import Home from '~/screens/Home';
+import OrderTracking from '~/screens/OrderTracking';
 import LocationPermissionScreen from '~/screens/LocationPermissionScreen';
 import LocationSelectionScreen from '~/screens/LocationSelectionScreen';
 import ProfileScreen from '~/screens/Profile/ProfileScreen';
@@ -122,6 +123,7 @@ const RootNavigator = () => {
           <Stack.Screen name="Search" component={SearchScreen} />
           <Stack.Screen name="Cart" component={Cart} />
           <Stack.Screen name="CheckoutOrder" component={CheckoutOrder} />
+          <Stack.Screen name="OrderTracking" component={OrderTracking} />
           <Stack.Screen name="CouponCode" component={CouponCode} />
           <Stack.Screen name="Profile" component={ProfileScreen} />
           <Stack.Screen name="OrderHistory" component={OrderHistoryScreen} />

--- a/src/screens/MenuDetail.tsx
+++ b/src/screens/MenuDetail.tsx
@@ -503,8 +503,8 @@ const MenuDetail: React.FC<MenuDetailProps> = ({
         customHeader={detailHeader}
         collapsedHeader={collapsedHeader}
         mainContent={mainContent}
-        headerMaxHeight={160}
-        headerMinHeight={140}
+        headerMaxHeight={180}
+        headerMinHeight={160}
       />
       {orderBar}
     </View>

--- a/src/screens/OrderTracking.tsx
+++ b/src/screens/OrderTracking.tsx
@@ -381,8 +381,9 @@ const OrderTrackingScreen: React.FC = () => {
     <View style={styles.stepsCard}>
       <View style={styles.stepsHeader}>
         <Text style={styles.stepsTitle}>Order Steps</Text>
-        <View style={styles.stepsStatusPill}>
-          <Text style={styles.stepsStatusText}>4 m 34s</Text>
+        <View style={styles.stepsTimer}>
+          <Clock size={18} color={accentColor} />
+          <Text style={styles.stepsTimerText}>4 m 34s</Text>
         </View>
       </View>
       {steps.map((step, index) => {
@@ -419,11 +420,11 @@ const OrderTrackingScreen: React.FC = () => {
               ) : null}
             </View>
             <View style={styles.stepTexts}>
-              <Text style={styles.stepStage}>Step {index + 1}</Text>
               <Text style={styles.stepTitle}>{step.title}</Text>
               <Text style={styles.stepDescription}>{step.description}</Text>
             </View>
-              <View style={styles.stepMeta}>
+            <View style={styles.stepMeta}>
+              {(isCompleted || isActive) && (
                 <View
                   style={[
                     styles.stepStatusBadge,
@@ -440,15 +441,16 @@ const OrderTrackingScreen: React.FC = () => {
                     {step.statusText}
                   </Text>
                 </View>
-                <View style={styles.stepEtaBadge}>
-                  <Text style={styles.stepEtaText}>{step.etaLabel}</Text>
-                </View>
+              )}
+              <View style={styles.stepEtaBadge}>
+                <Text style={styles.stepEtaText}>{step.etaLabel}</Text>
               </View>
             </View>
-          );
-        })}
-      </View>
-    );
+          </View>
+        );
+      })}
+    </View>
+  );
 
   return (
     <View style={styles.screen}>
@@ -659,51 +661,48 @@ const styles = StyleSheet.create({
   stepsCard: {
     backgroundColor: softSurface,
     borderRadius: 26,
-    paddingHorizontal: 22,
-    paddingVertical: 28,
+    paddingHorizontal: 24,
+    paddingVertical: 32,
     shadowColor: '#0F172A',
     shadowOpacity: 0.05,
     shadowRadius: 12,
     shadowOffset: { width: 0, height: 8 },
     elevation: 2,
-    marginBottom: 32,
+    marginBottom: 40,
   },
   stepsHeader: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    marginBottom: 20,
+    marginBottom: 24,
   },
   stepsTitle: {
     fontSize: 18,
     fontWeight: '700',
     color: textPrimary,
   },
-  stepsStatusPill: {
-    backgroundColor: accentColor,
-    borderRadius: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 6,
+  stepsTimer: {
+    flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'center',
   },
-  stepsStatusText: {
-    color: 'white',
+  stepsTimerText: {
+    marginLeft: 8,
+    color: accentColor,
     fontSize: 13,
     fontWeight: '700',
   },
   stepRow: {
     flexDirection: 'row',
     alignItems: 'flex-start',
-    paddingBottom: 20,
+    paddingBottom: 24,
   },
   stepRowDivider: {
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: borderColor,
-    marginBottom: 20,
+    marginBottom: 24,
   },
   stepTimeline: {
-    width: 34,
+    width: 36,
     alignItems: 'center',
   },
   stepDot: {
@@ -733,30 +732,22 @@ const styles = StyleSheet.create({
   },
   stepTexts: {
     flex: 1,
-    paddingRight: 12,
-  },
-  stepStage: {
-    fontSize: 12,
-    textTransform: 'uppercase',
-    letterSpacing: 0.8,
-    color: accentColor,
-    fontWeight: '600',
+    paddingRight: 16,
   },
   stepTitle: {
-    marginTop: 2,
-    fontSize: 15,
-    fontWeight: '600',
-    color: textPrimary,
+    fontSize: 16,
+    fontWeight: '700',
+    color: accentColor,
   },
   stepDescription: {
-    marginTop: 8,
+    marginTop: 6,
     fontSize: 13,
     lineHeight: 20,
     color: textSecondary,
   },
   stepMeta: {
     alignItems: 'flex-end',
-    width: 88,
+    width: 78,
   },
   stepStatusBadge: {
     paddingHorizontal: 12,
@@ -792,79 +783,79 @@ const styles = StyleSheet.create({
   },
   summaryCard: {
     backgroundColor: softSurface,
-    borderRadius: 20,
+    borderRadius: 18,
     paddingHorizontal: 16,
-    paddingVertical: 14,
+    paddingVertical: 12,
     shadowColor: '#0F172A',
-    shadowOpacity: 0.03,
-    shadowRadius: 6,
-    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.02,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
     elevation: 1,
-    marginBottom: 14,
+    marginBottom: 12,
   },
   summaryHeader: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    marginBottom: 12,
+    marginBottom: 10,
   },
   summaryTitle: {
-    fontSize: 15,
+    fontSize: 14,
     fontWeight: '700',
     color: textPrimary,
   },
   summaryBadge: {
     backgroundColor: '#FDE6E3',
     borderRadius: 999,
-    paddingHorizontal: 12,
-    paddingVertical: 5,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
   },
   summaryBadgeText: {
     color: accentColor,
-    fontSize: 12,
+    fontSize: 11,
     fontWeight: '600',
   },
   summaryItems: {
-    marginBottom: 12,
+    marginBottom: 10,
   },
   summaryItemRow: {
     flexDirection: 'row',
     alignItems: 'center',
   },
   summaryItemRowSpacing: {
-    marginBottom: 8,
+    marginBottom: 6,
   },
   summaryItemQuantity: {
-    fontSize: 12,
+    fontSize: 11,
     fontWeight: '600',
     color: accentColor,
     marginRight: 8,
   },
   summaryItemName: {
     flex: 1,
-    fontSize: 13,
+    fontSize: 12,
     color: textPrimary,
   },
   summaryFooter: {
-    marginTop: 12,
+    marginTop: 10,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
   },
   summaryTotal: {
-    fontSize: 15,
+    fontSize: 14,
     fontWeight: '700',
     color: textPrimary,
   },
   summaryDetailsButton: {
     borderRadius: 12,
-    paddingHorizontal: 14,
-    paddingVertical: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
     backgroundColor: accentColor,
   },
   summaryDetailsText: {
     color: 'white',
-    fontSize: 12,
+    fontSize: 11,
     fontWeight: '600',
   },
   bottomSheet: {
@@ -873,32 +864,32 @@ const styles = StyleSheet.create({
     right: 0,
     bottom: 0,
     paddingHorizontal: 16,
-    paddingTop: 12,
-    paddingBottom: 10,
+    paddingTop: 8,
+    paddingBottom: 8,
     backgroundColor: softBackground,
   },
   courierStickyCard: {
     backgroundColor: softSurface,
-    borderRadius: 20,
+    borderRadius: 18,
     paddingHorizontal: 16,
-    paddingVertical: 14,
+    paddingVertical: 12,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
     shadowColor: '#0F172A',
-    shadowOpacity: 0.03,
-    shadowRadius: 6,
-    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.02,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
     elevation: 1,
   },
   courierStickyLabel: {
     color: textSecondary,
-    fontSize: 12,
+    fontSize: 11,
     fontWeight: '600',
   },
   courierStickyName: {
     marginTop: 4,
-    fontSize: 16,
+    fontSize: 15,
     fontWeight: '700',
     color: textPrimary,
   },
@@ -909,7 +900,7 @@ const styles = StyleSheet.create({
   },
   courierStickyRatingText: {
     marginLeft: 6,
-    fontSize: 12,
+    fontSize: 11,
     color: textSecondary,
   },
   courierStickyActions: {
@@ -917,14 +908,14 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   courierActionButton: {
-    width: 42,
-    height: 42,
-    borderRadius: 14,
-    backgroundColor: '#FFECEB',
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    backgroundColor: '#F8F9FC',
     alignItems: 'center',
     justifyContent: 'center',
   },
   courierActionButtonSpacing: {
-    marginLeft: 10,
+    marginLeft: 8,
   },
 });

--- a/src/screens/OrderTracking.tsx
+++ b/src/screens/OrderTracking.tsx
@@ -351,8 +351,21 @@ const OrderTrackingScreen: React.FC = () => {
     };
   }, [timelineAnimations]);
 
-  const progressWidth = trackWidth ? Animated.multiply(progressAnim, trackWidth) : 0;
-  const riderTranslateX = trackWidth ? Animated.multiply(progressAnim, trackWidth) : 0;
+  const progressWidth = useMemo(() => {
+    if (!trackWidth) {
+      return 0;
+    }
+
+    return progressAnim.interpolate({ inputRange: [0, 1], outputRange: [0, trackWidth] });
+  }, [progressAnim, trackWidth]);
+
+  const riderTranslateX = useMemo(() => {
+    if (!trackWidth) {
+      return 0;
+    }
+
+    return progressAnim.interpolate({ inputRange: [0, 1], outputRange: [0, trackWidth] });
+  }, [progressAnim, trackWidth]);
   const riderTranslateY = bobAnim.interpolate({ inputRange: [0, 1], outputRange: [0, -8] });
   const pulseScale = pulseAnim.interpolate({ inputRange: [0, 1], outputRange: [1, 1.8] });
   const pulseOpacity = pulseAnim.interpolate({ inputRange: [0, 0.7, 1], outputRange: [0.35, 0.15, 0] });
@@ -505,8 +518,10 @@ const OrderTrackingScreen: React.FC = () => {
                 rotateEnabled={false}
                 pitchEnabled={false}
                 zoomEnabled={false}
-                pointerEvents="none"
                 customMapStyle={mapTheme}
+                showsBuildings
+                showsCompass={false}
+                showsPointsOfInterest={false}
               >
                 <Polyline
                   coordinates={routeCoordinates}
@@ -705,6 +720,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   mapCard: {
+    position: 'relative',
     height: 220,
     borderRadius: 32,
     overflow: 'hidden',
@@ -716,7 +732,8 @@ const styles = StyleSheet.create({
     elevation: 8,
   },
   map: {
-    ...StyleSheet.absoluteFillObject,
+    width: '100%',
+    height: '100%',
   },
   mapOverlay: {
     position: 'absolute',

--- a/src/screens/OrderTracking.tsx
+++ b/src/screens/OrderTracking.tsx
@@ -1,0 +1,620 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import type { ViewStyle } from 'react-native';
+import { Animated, Easing, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import {
+  NavigationProp,
+  ParamListBase,
+  RouteProp,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native';
+import { ArrowLeft, Bike, CheckCircle2, Clock, MapPin } from 'lucide-react-native';
+
+import type { CreateOrderResponse, MonetaryAmount } from '~/interfaces/Order';
+
+const accentColor = '#CA251B';
+const darkColor = '#17213A';
+const mutedTextColor = '#6B7280';
+const softSurface = '#F9FAFB';
+const chipBackground = 'rgba(255,255,255,0.18)';
+
+const parseMonetaryAmount = (value: MonetaryAmount | null | undefined) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.replace(',', '.');
+    const parsed = Number(normalized);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return 0;
+};
+
+const formatCurrency = (value: number) => `${value.toFixed(3)} dt`;
+
+const formatServerMoney = (value: MonetaryAmount | null | undefined) => formatCurrency(parseMonetaryAmount(value));
+
+const formatStatusLabel = (status?: string | null) => {
+  if (!status) {
+    return 'Pending';
+  }
+
+  const normalized = status.replace(/_/g, ' ');
+  return normalized.replace(/\b\w/g, (char) => char.toUpperCase());
+};
+
+type OrderTrackingRoute = RouteProp<{ OrderTracking: { order?: CreateOrderResponse | null } }, 'OrderTracking'>;
+
+interface TrackingStepBase {
+  key: string;
+  title: string;
+  description: string;
+}
+
+interface TrackingStep extends TrackingStepBase {
+  completed: boolean;
+  statusLabel?: string;
+}
+
+const DEFAULT_WORKFLOW_BASE: TrackingStepBase[] = [
+  {
+    key: 'CONFIRMED',
+    title: 'Order confirmed',
+    description: 'We let the restaurant know about your order.',
+  },
+  {
+    key: 'PREPARING',
+    title: 'Preparing your dishes',
+    description: 'Chefs are crafting your meal with fresh ingredients.',
+  },
+  {
+    key: 'READY_FOR_PICKUP',
+    title: 'Courier is picking up',
+    description: 'Your courier is heading to the restaurant.',
+  },
+  {
+    key: 'IN_TRANSIT',
+    title: 'On the way to you',
+    description: 'Keep an eye on the door, your order is nearby.',
+  },
+  {
+    key: 'DELIVERED',
+    title: 'Delivered',
+    description: 'Enjoy your meal and bon appétit! 🍽️',
+  },
+];
+
+const DEFAULT_STATUS_INDEX: Record<string, number> = {
+  PENDING: 0,
+  CONFIRMED: 0,
+  PREPARING: 1,
+  READY_FOR_PICKUP: 2,
+  IN_TRANSIT: 3,
+  DELIVERED: 4,
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const OrderTrackingScreen: React.FC = () => {
+  const navigation = useNavigation<NavigationProp<ParamListBase>>();
+  const route = useRoute<OrderTrackingRoute>();
+  const order = route.params?.order ?? null;
+
+  const { steps, activeIndex } = useMemo(() => {
+    if (order?.workflow?.length) {
+      const preparedSteps: TrackingStep[] = order.workflow.map((step, index) => {
+        const keyCandidate =
+          typeof step.step === 'string'
+            ? step.step.toUpperCase()
+            : typeof step.label === 'string'
+              ? step.label.toUpperCase().replace(/\s+/g, '_')
+              : `STEP_${index + 1}`;
+        const title =
+          (typeof step.label === 'string' && step.label.length > 0
+            ? step.label
+            : typeof step.step === 'string' && step.step.length > 0
+              ? formatStatusLabel(step.step)
+              : `Step ${index + 1}`) ?? `Step ${index + 1}`;
+        const statusLabel = typeof step.status === 'string' ? formatStatusLabel(step.status) : undefined;
+        const description =
+          typeof step.description === 'string' && step.description.length > 0
+            ? step.description
+            : statusLabel ?? 'We will keep you posted as soon as this updates.';
+
+        return {
+          key: keyCandidate,
+          title,
+          description,
+          statusLabel,
+          completed: Boolean(step.completed),
+        } satisfies TrackingStep;
+      });
+
+      const inProgressIndex = order.workflow.findIndex((step) => {
+        const status = typeof step.status === 'string' ? step.status.toUpperCase() : '';
+        return status === 'IN_PROGRESS' || status === 'ACTIVE' || status === 'ONGOING';
+      });
+
+      const lastCompletedIndex = order.workflow.reduce((acc, step, index) => (step.completed ? index : acc), -1);
+      const resolvedIndex = clamp(
+        inProgressIndex >= 0 ? inProgressIndex : lastCompletedIndex + 1,
+        0,
+        preparedSteps.length - 1,
+      );
+
+      return { steps: preparedSteps, activeIndex: resolvedIndex };
+    }
+
+    const normalizedStatus = typeof order?.status === 'string' ? order.status.toUpperCase() : 'PENDING';
+    const defaultIndex = DEFAULT_STATUS_INDEX[normalizedStatus] ?? 0;
+    const clampedIndex = clamp(defaultIndex, 0, DEFAULT_WORKFLOW_BASE.length - 1);
+    const isDelivered = normalizedStatus === 'DELIVERED';
+
+    const preparedSteps: TrackingStep[] = DEFAULT_WORKFLOW_BASE.map((step, index) => {
+      const isCurrent = index === clampedIndex;
+      const isCompleted = index < clampedIndex || (isDelivered && isCurrent);
+      const statusLabel = isCompleted ? 'Completed' : isCurrent ? 'In progress' : 'Pending';
+
+      return {
+        ...step,
+        completed: isCompleted,
+        statusLabel,
+      } satisfies TrackingStep;
+    });
+
+    return { steps: preparedSteps, activeIndex: clampedIndex };
+  }, [order]);
+
+  const activeStep = steps[activeIndex] ?? steps[0];
+  const safeProgress = steps.length > 1 ? clamp(activeIndex / (steps.length - 1), 0, 1) : 1;
+
+  const progressAnim = useRef(new Animated.Value(0)).current;
+  const bobAnim = useRef(new Animated.Value(0)).current;
+  const pulseAnim = useRef(new Animated.Value(0)).current;
+  const [trackWidth, setTrackWidth] = useState(0);
+
+  useEffect(() => {
+    Animated.timing(progressAnim, {
+      toValue: safeProgress,
+      duration: 900,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: false,
+    }).start();
+  }, [progressAnim, safeProgress]);
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(bobAnim, {
+          toValue: 1,
+          duration: 1300,
+          easing: Easing.inOut(Easing.sin),
+          useNativeDriver: true,
+        }),
+        Animated.timing(bobAnim, {
+          toValue: 0,
+          duration: 1300,
+          easing: Easing.inOut(Easing.sin),
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+
+    animation.start();
+    return () => {
+      animation.stop();
+    };
+  }, [bobAnim]);
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulseAnim, {
+          toValue: 1,
+          duration: 1600,
+          easing: Easing.out(Easing.quad),
+          useNativeDriver: true,
+        }),
+        Animated.timing(pulseAnim, {
+          toValue: 0,
+          duration: 0,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+
+    animation.start();
+    return () => {
+      animation.stop();
+    };
+  }, [pulseAnim]);
+
+  const stepsCount = steps.length;
+  const timelineAnimations = useMemo(
+    () => Array.from({ length: stepsCount }, () => new Animated.Value(0)),
+    [stepsCount],
+  );
+
+  useEffect(() => {
+    timelineAnimations.forEach((value) => value.setValue(0));
+    const animations = timelineAnimations.map((value, index) =>
+      Animated.timing(value, {
+        toValue: 1,
+        duration: 450,
+        delay: index * 110,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+    );
+    const controller = Animated.stagger(110, animations);
+    controller.start();
+
+    return () => {
+      controller.stop();
+    };
+  }, [timelineAnimations]);
+
+  const progressWidth = trackWidth ? Animated.multiply(progressAnim, trackWidth) : 0;
+  const riderTranslateX = trackWidth ? Animated.multiply(progressAnim, trackWidth) : 0;
+  const riderTranslateY = bobAnim.interpolate({ inputRange: [0, 1], outputRange: [0, -8] });
+  const pulseScale = pulseAnim.interpolate({ inputRange: [0, 1], outputRange: [1, 1.8] });
+  const pulseOpacity = pulseAnim.interpolate({ inputRange: [0, 0.7, 1], outputRange: [0.35, 0.15, 0] });
+
+  const restaurantName = order?.restaurant?.name ?? 'your restaurant';
+  const orderIdLabel = order ? `#${order.orderId}` : 'Live order';
+  const deliveryAddress = order?.delivery?.address ?? 'Your saved address';
+  const addressLabel = order?.delivery?.savedAddress?.label ?? 'Delivery';
+  const trimmedAddress = deliveryAddress.length > 80 ? `${deliveryAddress.slice(0, 77)}...` : deliveryAddress;
+  const estimatedWindow = useMemo(() => {
+    if (!order) {
+      return '35-45 min';
+    }
+
+    const itemCount = order.items?.length ?? 0;
+    const base = 28 + Math.min(itemCount * 4, 12);
+    const start = Math.max(18, base - 6);
+    const end = base + 6;
+    return `${start}-${end} min`;
+  }, [order]);
+
+  const orderTotal = order ? formatServerMoney(order.payment?.total) : undefined;
+  const paymentMethod = order?.payment?.method ?? 'Selected method';
+  const displayedItems = useMemo(() => (order?.items ?? []).slice(0, 3), [order?.items]);
+  const remainingItems = Math.max(0, (order?.items?.length ?? 0) - displayedItems.length);
+
+  return (
+    <SafeAreaView className="flex-1 bg-white">
+      <ScrollView className="flex-1" contentContainerStyle={{ paddingBottom: 32 }}>
+        <View>
+          <LinearGradient
+            colors={[accentColor, '#E75A4D']}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={styles.heroGradient}
+          >
+            <View className="px-6 pt-2 pb-12">
+              <View className="flex-row items-center justify-between">
+                <TouchableOpacity
+                  onPress={() => navigation.goBack()}
+                  activeOpacity={0.85}
+                  className="h-11 w-11 items-center justify-center rounded-full bg-white/20"
+                >
+                  <ArrowLeft color="white" size={22} />
+                </TouchableOpacity>
+                <View className="rounded-full bg-white/15 px-4 py-2">
+                  <Text allowFontScaling={false} className="text-xs font-semibold uppercase tracking-[2px] text-white/90">
+                    {orderIdLabel}
+                  </Text>
+                </View>
+              </View>
+
+              <View className="mt-8">
+                <Text allowFontScaling={false} className="text-xs font-semibold uppercase tracking-[4px] text-white/70">
+                  Now
+                </Text>
+                <Text allowFontScaling={false} className="mt-3 text-3xl font-bold text-white">
+                  {activeStep?.title ?? 'Order in progress'}
+                </Text>
+                <Text allowFontScaling={false} className="mt-3 text-sm leading-5 text-white/85">
+                  {activeStep?.description ?? `We are looking after your order from ${restaurantName}.`}
+                </Text>
+                <Text allowFontScaling={false} className="mt-4 text-xs uppercase tracking-[3px] text-white/70">
+                  From {restaurantName}
+                </Text>
+              </View>
+
+              <View className="mt-6 flex-row flex-wrap gap-3">
+                <View className="flex-row items-center rounded-full px-4 py-2" style={{ backgroundColor: chipBackground }}>
+                  <Clock size={18} color="white" />
+                  <Text allowFontScaling={false} className="ml-2 text-sm font-semibold text-white">
+                    {estimatedWindow}
+                  </Text>
+                </View>
+                <View className="flex-row items-center rounded-full px-4 py-2" style={{ backgroundColor: chipBackground }}>
+                  <Bike size={18} color="white" />
+                  <Text allowFontScaling={false} className="ml-2 text-sm font-semibold text-white">
+                    {activeStep?.statusLabel ?? 'In progress'}
+                  </Text>
+                </View>
+              </View>
+
+              <View className="mt-6 rounded-3xl bg-white/15 p-4">
+                <View className="flex-row items-center">
+                  <View className="h-10 w-10 items-center justify-center rounded-2xl bg-white/20">
+                    <MapPin size={20} color="white" />
+                  </View>
+                  <View className="ml-3 flex-1">
+                    <Text allowFontScaling={false} className="text-xs font-semibold uppercase text-white/70">
+                      {addressLabel}
+                    </Text>
+                    <Text allowFontScaling={false} className="mt-1 text-sm font-semibold text-white">
+                      {trimmedAddress}
+                    </Text>
+                  </View>
+                </View>
+              </View>
+
+              <View className="mt-8">
+                <View
+                  style={styles.trackContainer}
+                  onLayout={(event) => setTrackWidth(event.nativeEvent.layout.width)}
+                >
+                  <View style={styles.trackBackground} />
+                  <Animated.View style={[styles.trackProgress, { width: progressWidth }]} />
+                  <Animated.View
+                    style={[
+                      styles.riderContainer,
+                      {
+                        transform: [
+                          { translateX: riderTranslateX },
+                          { translateY: riderTranslateY },
+                        ],
+                      },
+                    ]}
+                  >
+                    <Animated.View
+                      style={[
+                        styles.riderPulse,
+                        {
+                          transform: [{ scale: pulseScale }],
+                          opacity: pulseOpacity,
+                        },
+                      ]}
+                    />
+                    <View style={styles.riderIconWrapper}>
+                      <Bike size={22} color="white" />
+                    </View>
+                  </Animated.View>
+                </View>
+                <View className="mt-3 flex-row items-center justify-between">
+                  <Text allowFontScaling={false} className="text-xs font-semibold uppercase text-white/80">
+                    Start
+                  </Text>
+                  <Text allowFontScaling={false} className="text-xs font-semibold uppercase text-white/80">
+                    Finish
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </LinearGradient>
+
+          <View className="-mt-10 px-6">
+            <View style={styles.card}>
+              <Text allowFontScaling={false} className="text-base font-semibold" style={{ color: darkColor }}>
+                Live order status
+              </Text>
+              {steps.map((step, index) => {
+                const isActive = index === activeIndex;
+                const isCompleted = index < activeIndex || (steps.length - 1 === index && step.completed);
+                const timelineValue = timelineAnimations[index];
+                const animatedStyle: Animated.WithAnimatedObject<ViewStyle> | null = timelineValue
+                  ? {
+                      opacity: timelineValue,
+                      transform: [
+                        {
+                          translateY: timelineValue.interpolate({ inputRange: [0, 1], outputRange: [20, 0] }),
+                        },
+                      ],
+                    }
+                  : null;
+
+                return (
+                  <Animated.View
+                    key={`${step.key}-${index}`}
+                    className="mt-6 flex-row"
+                    style={animatedStyle ?? undefined}
+                  >
+                    <View className="items-center" style={{ width: 28 }}>
+                      <View
+                        className="items-center justify-center rounded-full"
+                        style={[
+                          styles.timelineDot,
+                          {
+                            backgroundColor: isCompleted || isActive ? accentColor : '#FFFFFF',
+                            borderColor: isCompleted || isActive ? accentColor : '#E5E7EB',
+                          },
+                        ]}
+                      >
+                        {isCompleted ? <CheckCircle2 size={14} color="white" /> : null}
+                      </View>
+                      {index < steps.length - 1 ? (
+                        <View
+                          style={[
+                            styles.timelineLine,
+                            { backgroundColor: isCompleted ? `${accentColor}66` : '#E5E7EB' },
+                          ]}
+                        />
+                      ) : null}
+                    </View>
+                    <View className="ml-4 flex-1">
+                      <Text
+                        allowFontScaling={false}
+                        className="text-sm font-semibold"
+                        style={{ color: isActive ? accentColor : darkColor }}
+                      >
+                        {step.title}
+                      </Text>
+                      <Text allowFontScaling={false} className="mt-1 text-xs leading-5" style={{ color: mutedTextColor }}>
+                        {step.description}
+                      </Text>
+                      {step.statusLabel ? (
+                        <View className="mt-2 self-start rounded-full bg-[#FDE7E5] px-3 py-1">
+                          <Text allowFontScaling={false} className="text-[11px] font-semibold uppercase text-[#CA251B]">
+                            {step.statusLabel}
+                          </Text>
+                        </View>
+                      ) : null}
+                    </View>
+                  </Animated.View>
+                );
+              })}
+            </View>
+
+            <View style={[styles.card, { marginTop: 24 }]}> 
+              <Text allowFontScaling={false} className="text-base font-semibold" style={{ color: darkColor }}>
+                Order summary
+              </Text>
+              <View className="mt-4 rounded-2xl px-4 py-4" style={{ backgroundColor: softSurface }}>
+                <View className="flex-row items-center justify-between">
+                  <Text allowFontScaling={false} className="text-sm font-semibold" style={{ color: darkColor }}>
+                    Total paid
+                  </Text>
+                  <Text allowFontScaling={false} className="text-lg font-bold" style={{ color: accentColor }}>
+                    {orderTotal ?? '—'}
+                  </Text>
+                </View>
+                <Text allowFontScaling={false} className="mt-2 text-xs" style={{ color: mutedTextColor }}>
+                  {`Payment method: ${paymentMethod}`}
+                </Text>
+              </View>
+
+              {displayedItems.length ? (
+                <View className="mt-4 rounded-2xl border border-dashed border-[#E5E7EB] px-4 py-4">
+                  {displayedItems.map((item) => (
+                    <View key={`${item.menuItemId}-${item.name}`} className="mt-3 flex-row items-start justify-between">
+                      <View className="flex-1 pr-3">
+                        <Text allowFontScaling={false} className="text-sm font-semibold" style={{ color: darkColor }}>
+                          {item.quantity} × {item.name}
+                        </Text>
+                        {item.extras?.length ? (
+                          <Text allowFontScaling={false} className="mt-1 text-xs" style={{ color: mutedTextColor }}>
+                            Extras: {item.extras.map((extra) => extra.name).join(', ')}
+                          </Text>
+                        ) : null}
+                      </View>
+                      <Text allowFontScaling={false} className="text-sm font-semibold" style={{ color: darkColor }}>
+                        {formatServerMoney(item.lineTotal)}
+                      </Text>
+                    </View>
+                  ))}
+                  {remainingItems > 0 ? (
+                    <Text allowFontScaling={false} className="mt-3 text-xs" style={{ color: mutedTextColor }}>
+                      + {remainingItems} more {remainingItems === 1 ? 'item' : 'items'}
+                    </Text>
+                  ) : null}
+                </View>
+              ) : null}
+
+              <View className="mt-6 flex-row gap-3">
+                <TouchableOpacity
+                  activeOpacity={0.88}
+                  onPress={() => navigation.navigate('OrderHistory')}
+                  className="flex-1 rounded-full border border-[#E5E7EB] px-4 py-3"
+                >
+                  <Text allowFontScaling={false} className="text-center text-sm font-semibold" style={{ color: darkColor }}>
+                    View order history
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  activeOpacity={0.9}
+                  onPress={() => navigation.navigate('Home')}
+                  className="flex-1 rounded-full bg-[#17213A] px-4 py-3"
+                >
+                  <Text allowFontScaling={false} className="text-center text-sm font-semibold text-white">
+                    Back to home
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  heroGradient: {
+    borderBottomLeftRadius: 32,
+    borderBottomRightRadius: 32,
+    overflow: 'hidden',
+  },
+  trackContainer: {
+    height: 14,
+    borderRadius: 9999,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    overflow: 'hidden',
+  },
+  trackBackground: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(255,255,255,0.15)',
+  },
+  trackProgress: {
+    height: '100%',
+    borderRadius: 9999,
+    backgroundColor: 'rgba(255,255,255,0.9)',
+  },
+  riderContainer: {
+    position: 'absolute',
+    top: -22,
+  },
+  riderPulse: {
+    position: 'absolute',
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: accentColor,
+  },
+  riderIconWrapper: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: accentColor,
+    shadowColor: accentColor,
+    shadowOpacity: 0.35,
+    shadowRadius: 16,
+    shadowOffset: { width: 0, height: 10 },
+    elevation: 6,
+  },
+  card: {
+    borderRadius: 32,
+    backgroundColor: 'white',
+    padding: 24,
+    shadowColor: darkColor,
+    shadowOpacity: 0.08,
+    shadowRadius: 24,
+    shadowOffset: { width: 0, height: 12 },
+    elevation: 6,
+  },
+  timelineDot: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    borderWidth: 2,
+  },
+  timelineLine: {
+    width: 2,
+    flex: 1,
+    marginTop: 6,
+  },
+});
+
+export default OrderTrackingScreen;

--- a/src/screens/OrderTracking.tsx
+++ b/src/screens/OrderTracking.tsx
@@ -396,6 +396,13 @@ const OrderTrackingScreen: React.FC = () => {
         const isLast = index === steps.length - 1;
         const isCompleted = step.state === 'completed';
         const isActive = step.state === 'active';
+        const isPending = !isCompleted && !isActive;
+        const previousStep = index > 0 ? steps[index - 1] : null;
+
+        const topConnectorActive =
+          index > 0 &&
+          (previousStep?.state === 'completed' || previousStep?.state === 'active');
+        const bottomConnectorActive = !isLast && isCompleted;
 
         return (
           <View
@@ -403,11 +410,22 @@ const OrderTrackingScreen: React.FC = () => {
             style={[styles.stepRow, !isLast && styles.stepRowDivider]}
           >
             <View style={styles.stepTimeline}>
+              {index > 0 ? (
+                <View
+                  style={[
+                    styles.stepConnector,
+                    styles.stepConnectorTop,
+                    topConnectorActive && styles.stepConnectorActive,
+                  ]}
+                />
+              ) : null}
+
               <View
                 style={[
                   styles.stepDot,
                   isCompleted && styles.stepDotCompleted,
                   isActive && styles.stepDotActive,
+                  isPending && styles.stepDotPending,
                 ]}
               >
                 {isCompleted ? (
@@ -416,18 +434,35 @@ const OrderTrackingScreen: React.FC = () => {
                   <Clock size={12} color={accentColor} />
                 ) : null}
               </View>
+
               {!isLast ? (
                 <View
                   style={[
-                    styles.stepLine,
-                    (isCompleted || isActive) && styles.stepLineActive,
+                    styles.stepConnector,
+                    styles.stepConnectorBottom,
+                    bottomConnectorActive && styles.stepConnectorActive,
                   ]}
                 />
               ) : null}
             </View>
             <View style={styles.stepTexts}>
-              <Text style={styles.stepTitle}>{step.title}</Text>
-              <Text style={styles.stepDescription}>{step.description}</Text>
+              <Text
+                style={[
+                  styles.stepTitle,
+                  (isCompleted || isActive) && styles.stepTitleActive,
+                  isPending && styles.stepTitlePending,
+                ]}
+              >
+                {step.title}
+              </Text>
+              <Text
+                style={[
+                  styles.stepDescription,
+                  isPending && styles.stepDescriptionPending,
+                ]}
+              >
+                {step.description}
+              </Text>
             </View>
             <View style={styles.stepMeta}>
               {(isCompleted || isActive) && (
@@ -448,8 +483,20 @@ const OrderTrackingScreen: React.FC = () => {
                   </Text>
                 </View>
               )}
-              <View style={styles.stepEtaBadge}>
-                <Text style={styles.stepEtaText}>{step.etaLabel}</Text>
+              <View
+                style={[
+                  styles.stepEtaBadge,
+                  isPending && styles.stepEtaBadgePending,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.stepEtaText,
+                    isPending && styles.stepEtaTextPending,
+                  ]}
+                >
+                  {step.etaLabel}
+                </Text>
               </View>
             </View>
           </View>
@@ -718,7 +765,27 @@ const styles = StyleSheet.create({
   },
   stepTimeline: {
     width: 36,
+    minHeight: 24,
     alignItems: 'center',
+    justifyContent: 'center',
+    position: 'relative',
+  },
+  stepConnector: {
+    position: 'absolute',
+    width: 2,
+    backgroundColor: '#E5E7EB',
+    left: 17,
+  },
+  stepConnectorTop: {
+    top: -24,
+    bottom: 24,
+  },
+  stepConnectorBottom: {
+    top: 24,
+    bottom: -24,
+  },
+  stepConnectorActive: {
+    backgroundColor: accentColor,
   },
   stepDot: {
     width: 24,
@@ -727,6 +794,8 @@ const styles = StyleSheet.create({
     borderWidth: 3,
     borderColor: '#E5E7EB',
     backgroundColor: '#FFFFFF',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   stepDotCompleted: {
     backgroundColor: accentColor,
@@ -735,15 +804,8 @@ const styles = StyleSheet.create({
   stepDotActive: {
     borderColor: accentColor,
   },
-  stepLine: {
-    position: 'absolute',
-    top: 24,
-    bottom: -20,
-    width: 2,
-    backgroundColor: '#E5E7EB',
-  },
-  stepLineActive: {
-    backgroundColor: accentColor,
+  stepDotPending: {
+    borderColor: '#E2E8F0',
   },
   stepTexts: {
     flex: 1,
@@ -752,13 +814,21 @@ const styles = StyleSheet.create({
   stepTitle: {
     fontSize: 16,
     fontWeight: '700',
+  },
+  stepTitleActive: {
     color: accentColor,
+  },
+  stepTitlePending: {
+    color: '#A0AEC0',
   },
   stepDescription: {
     marginTop: 6,
     fontSize: 13,
     lineHeight: 20,
     color: textSecondary,
+  },
+  stepDescriptionPending: {
+    color: '#C5CCD8',
   },
   stepMeta: {
     alignItems: 'flex-end',
@@ -791,10 +861,17 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     paddingVertical: 4,
   },
+  stepEtaBadgePending: {
+    backgroundColor: '#EEF2F6',
+  },
   stepEtaText: {
     color: '#FFFFFF',
     fontSize: 12,
     fontWeight: '700',
+  },
+  stepEtaTextPending: {
+    color: '#9CA3AF',
+    fontWeight: '600',
   },
   summaryCard: {
     backgroundColor: softSurface,

--- a/src/screens/OrderTracking.tsx
+++ b/src/screens/OrderTracking.tsx
@@ -1,8 +1,21 @@
-import React, { useEffect, useMemo, useRef } from 'react';
-import type { ViewStyle } from 'react-native';
-import { Animated, Easing, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import MapView, { Marker, Polyline, type MapStyleElement, type Region } from 'react-native-maps';
+import React, { useMemo } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+} from 'react-native';
+import MapView, { Marker, Polyline, type Region } from 'react-native-maps';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  ArrowLeft,
+  Bike,
+  Clock,
+  MapPin,
+  Phone,
+  Star,
+} from 'lucide-react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import {
   NavigationProp,
@@ -11,55 +24,16 @@ import {
   useNavigation,
   useRoute,
 } from '@react-navigation/native';
-import { ArrowLeft, Bike, CheckCircle2, Clock, MapPin, Phone } from 'lucide-react-native';
 
 import type { CreateOrderResponse, MonetaryAmount } from '~/interfaces/Order';
 import MainLayout from '~/layouts/MainLayout';
 
 const accentColor = '#D83A2E';
-const accentMuted = '#FBE5E1';
-const heroText = '#0F172A';
-const softSurface = '#FFFFFF';
 const softBackground = '#F5F6FA';
-const secondaryText = '#6B7280';
-
-const mapTheme: MapStyleElement[] = [
-  { elementType: 'geometry', stylers: [{ color: '#E7ECF5' }] },
-  { elementType: 'labels.text.fill', stylers: [{ color: '#2E3A4A' }] },
-  { elementType: 'labels.text.stroke', stylers: [{ color: '#FFFFFF' }] },
-  {
-    featureType: 'poi',
-    elementType: 'labels.text',
-    stylers: [{ visibility: 'off' }],
-  },
-  {
-    featureType: 'road',
-    elementType: 'geometry',
-    stylers: [{ color: '#FFFFFF' }],
-  },
-  {
-    featureType: 'road.arterial',
-    elementType: 'geometry',
-    stylers: [{ color: '#D8DEE9' }],
-  },
-  {
-    featureType: 'road.highway',
-    elementType: 'geometry',
-    stylers: [{ color: '#CBD5E1' }],
-  },
-  {
-    featureType: 'transit',
-    elementType: 'labels.icon',
-    stylers: [{ visibility: 'off' }],
-  },
-  {
-    featureType: 'water',
-    elementType: 'geometry',
-    stylers: [{ color: '#C5DAF7' }],
-  },
-];
-
-type LatLng = { latitude: number; longitude: number };
+const softSurface = '#FFFFFF';
+const textPrimary = '#0F172A';
+const textSecondary = '#6B7280';
+const borderColor = '#F0F1F5';
 
 const DEFAULT_REGION: Region = {
   latitude: 36.8065,
@@ -68,302 +42,225 @@ const DEFAULT_REGION: Region = {
   longitudeDelta: 0.04,
 };
 
-const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
-
-const parseMonetaryAmount = (value: MonetaryAmount | null | undefined) => {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value;
-  }
-
-  if (typeof value === 'string') {
-    const parsed = Number(value.replace(',', '.'));
-    if (Number.isFinite(parsed)) {
-      return parsed;
-    }
-  }
-
-  return 0;
+const MOCK_ORDER: CreateOrderResponse = {
+  orderId: 'FO-2024-1834',
+  status: 'READY_FOR_PICKUP',
+  restaurant: {
+    name: 'Tacos XL',
+  },
+  items: [
+    {
+      quantity: 2,
+      menuItem: {
+        id: 'item-1',
+        name: 'Crispy Chicken Wrap',
+      },
+    },
+    {
+      quantity: 1,
+      menuItem: {
+        id: 'item-2',
+        name: 'Loaded Fries',
+      },
+    },
+  ],
+  payment: {
+    total: '28.500',
+  },
+  delivery: {
+    address: '221 Market Street, Downtown, San Francisco, CA',
+    savedAddress: {
+      label: 'San Francisco Bay Area',
+    },
+    courier: {
+      name: 'Jaafar',
+      rating: 4.9,
+      totalDeliveries: 152,
+    },
+    location: {
+      lat: DEFAULT_REGION.latitude + 0.01,
+      lng: DEFAULT_REGION.longitude + 0.008,
+    },
+  },
+  workflow: [
+    {
+      step: 'ACCEPTED',
+      label: 'Accepted by the Restaurant',
+      description: 'Your order is being prepared fresh & hot.',
+      status: 'COMPLETED',
+      completed: true,
+    },
+    {
+      step: 'READY_FOR_PICKUP',
+      label: 'Ready to Pickup',
+      description: 'The courier is heading to the restaurant to pick up your order.',
+      status: 'IN_PROGRESS',
+      completed: false,
+    },
+    {
+      step: 'ON_THE_WAY',
+      label: 'On the way',
+      description: 'The courier is as fast as possible heading to you.',
+      status: 'PENDING',
+      completed: false,
+    },
+    {
+      step: 'FOOD_IS_HERE',
+      label: 'Food is here',
+      description: 'The courier is a few meters away.',
+      status: 'PENDING',
+      completed: false,
+    },
+    {
+      step: 'DELIVERED',
+      label: 'Delivered',
+      description: 'Enjoy your meal! The order has been delivered.',
+      status: 'PENDING',
+      completed: false,
+    },
+  ],
 };
 
-const formatCurrency = (value: number) => `${value.toFixed(3)} dt`;
+type OrderTrackingRoute = RouteProp<
+  { OrderTracking: { order?: CreateOrderResponse | null } },
+  'OrderTracking'
+>;
 
-const formatServerMoney = (value: MonetaryAmount | null | undefined) => formatCurrency(parseMonetaryAmount(value));
+type LatLng = { latitude: number; longitude: number };
 
-const formatStatusLabel = (status?: string | null) => {
-  if (!status) {
-    return 'Pending';
-  }
-
-  const normalized = status.replace(/_/g, ' ');
-  return normalized.replace(/\b\w/g, (char) => char.toUpperCase());
-};
-
-type OrderTrackingRoute = RouteProp<{ OrderTracking: { order?: CreateOrderResponse | null } }, 'OrderTracking'>;
-
-interface TrackingStepBase {
+type WorkflowStep = {
   key: string;
   title: string;
   description: string;
-}
+  statusText: string;
+  etaLabel: string;
+  state: 'completed' | 'active' | 'pending';
+};
 
-interface TrackingStep extends TrackingStepBase {
-  completed: boolean;
-  statusLabel?: string;
-}
+const formatCurrency = (value: MonetaryAmount | null | undefined) => {
+  if (value == null) {
+    return undefined;
+  }
 
-const DEFAULT_WORKFLOW_BASE: TrackingStepBase[] = [
-  {
-    key: 'CONFIRMED',
-    title: 'Order confirmed',
-    description: 'We let the restaurant know about your order.',
-  },
-  {
-    key: 'PREPARING',
-    title: 'Preparing your dishes',
-    description: 'Chefs are cooking your meal with fresh ingredients.',
-  },
-  {
-    key: 'READY_FOR_PICKUP',
-    title: 'Courier is picking up',
-    description: 'Your courier is heading to the restaurant.',
-  },
-  {
-    key: 'IN_TRANSIT',
-    title: 'On the way to you',
-    description: 'Keep an eye on the door, your order is nearby.',
-  },
-  {
-    key: 'DELIVERED',
-    title: 'Delivered',
-    description: 'Enjoy your meal and bon appétit! 🍽️',
-  },
-];
+  if (typeof value === 'number') {
+    return `${value.toFixed(3)} dt`;
+  }
 
-const DEFAULT_STATUS_INDEX: Record<string, number> = {
-  PENDING: 0,
-  CONFIRMED: 0,
-  PREPARING: 1,
-  READY_FOR_PICKUP: 2,
-  IN_TRANSIT: 3,
-  DELIVERED: 4,
+  const parsed = Number(String(value).replace(',', '.'));
+  if (Number.isFinite(parsed)) {
+    return `${parsed.toFixed(3)} dt`;
+  }
+
+  return undefined;
+};
+
+const buildWorkflowSteps = (order: CreateOrderResponse | null | undefined): WorkflowStep[] => {
+  const fallbackSteps: WorkflowStep[] = MOCK_ORDER.workflow!.map((step, index) => {
+    const state = index === 0 ? 'completed' : index === 1 ? 'active' : 'pending';
+    return {
+      key: step.step ?? `STEP_${index}`,
+      title: step.label ?? `Step ${index + 1}`,
+      description: step.description ?? 'We will notify you once this updates.',
+      statusText:
+        index === 0 ? 'Completed' : index === 1 ? 'Preparing' : 'Pending',
+      etaLabel: index === 0 ? '4 m 34s' : index === 1 ? '24s' : '0s',
+      state,
+    } satisfies WorkflowStep;
+  });
+
+  if (!order?.workflow?.length) {
+    return fallbackSteps;
+  }
+
+  return order.workflow.map((step, index) => {
+    const status = String(step.status ?? '').toUpperCase();
+    let state: WorkflowStep['state'] = 'pending';
+    if (status === 'COMPLETED' || step.completed) {
+      state = 'completed';
+    } else if (status === 'IN_PROGRESS' || status === 'ACTIVE') {
+      state = 'active';
+    }
+
+    return {
+      key: step.step ?? `STEP_${index}`,
+      title: step.label ?? `Step ${index + 1}`,
+      description: step.description ?? 'We will notify you once this updates.',
+      statusText:
+        state === 'completed' ? 'Completed' : state === 'active' ? 'Preparing' : 'Pending',
+      etaLabel:
+        index === 0 ? '4 m 34s' : index === 1 ? '24s' : index === 2 ? '0s' : '1m 20s',
+      state,
+    } satisfies WorkflowStep;
+  });
 };
 
 const OrderTrackingScreen: React.FC = () => {
   const navigation = useNavigation<NavigationProp<ParamListBase>>();
   const route = useRoute<OrderTrackingRoute>();
-  const order = route.params?.order ?? null;
   const insets = useSafeAreaInsets();
 
-  const { steps, activeIndex } = useMemo(() => {
-    if (order?.workflow?.length) {
-      const preparedSteps: TrackingStep[] = order.workflow.map((step, index) => {
-        const keyCandidate =
-          typeof step.step === 'string'
-            ? step.step.toUpperCase()
-            : typeof step.label === 'string'
-            ? step.label.toUpperCase().replace(/\s+/g, '_')
-            : `STEP_${index + 1}`;
-        const title =
-          (typeof step.label === 'string' && step.label.length > 0
-            ? step.label
-            : typeof step.step === 'string' && step.step.length > 0
-            ? formatStatusLabel(step.step)
-            : `Step ${index + 1}`) ?? `Step ${index + 1}`;
-        const statusLabel = typeof step.status === 'string' ? formatStatusLabel(step.status) : undefined;
-        const description =
-          typeof step.description === 'string' && step.description.length > 0
-            ? step.description
-            : statusLabel ?? 'We will keep you posted as soon as this updates.';
+  const order = route.params?.order ?? MOCK_ORDER;
 
-        return {
-          key: keyCandidate,
-          title,
-          description,
-          statusLabel,
-          completed: Boolean(step.completed),
-        } satisfies TrackingStep;
-      });
+  const steps = useMemo(() => buildWorkflowSteps(order), [order]);
 
-      const inProgressIndex = order.workflow.findIndex((step) => {
-        const status = typeof step.status === 'string' ? step.status.toUpperCase() : '';
-        return status === 'IN_PROGRESS' || status === 'ACTIVE' || status === 'ONGOING';
-      });
-
-      const lastCompletedIndex = order.workflow.reduce((acc, step, index) => (step.completed ? index : acc), -1);
-      const resolvedIndex = clamp(
-        inProgressIndex >= 0 ? inProgressIndex : lastCompletedIndex + 1,
-        0,
-        preparedSteps.length - 1,
-      );
-
-      return { steps: preparedSteps, activeIndex: resolvedIndex };
-    }
-
-    const normalizedStatus = typeof order?.status === 'string' ? order.status.toUpperCase() : 'PENDING';
-    const defaultIndex = DEFAULT_STATUS_INDEX[normalizedStatus] ?? 0;
-    const clampedIndex = clamp(defaultIndex, 0, DEFAULT_WORKFLOW_BASE.length - 1);
-    const isDelivered = normalizedStatus === 'DELIVERED';
-
-    const preparedSteps: TrackingStep[] = DEFAULT_WORKFLOW_BASE.map((step, index) => {
-      const isCurrent = index === clampedIndex;
-      const isCompleted = index < clampedIndex || (isDelivered && isCurrent);
-      const statusLabel = isCompleted ? 'Completed' : isCurrent ? 'In progress' : 'Pending';
-
-      return {
-        ...step,
-        completed: isCompleted,
-        statusLabel,
-      } satisfies TrackingStep;
-    });
-
-    return { steps: preparedSteps, activeIndex: clampedIndex };
-  }, [order]);
-
-  const activeStep = steps[activeIndex] ?? steps[0];
-  const safeProgress = steps.length > 1 ? clamp(activeIndex / (steps.length - 1), 0, 1) : 1;
-
-  const deliveryLocation = order?.delivery?.location;
+  const orderTotal = formatCurrency(order?.payment?.total);
+  const deliveryArea = order?.delivery?.savedAddress?.label ?? 'San Francisco Bay Area';
+  const deliveryAddress = order?.delivery?.address ?? 'Your delivery address';
+  const parsedCourierRating = Number(order?.delivery?.courier?.rating ?? NaN);
+  const courierRating = Number.isFinite(parsedCourierRating)
+    ? parsedCourierRating.toFixed(1)
+    : '5.0';
+  const courierDeliveriesValue = Number(order?.delivery?.courier?.totalDeliveries ?? NaN);
+  const courierDeliveries = Number.isFinite(courierDeliveriesValue)
+    ? courierDeliveriesValue
+    : 120;
+  const courierName = order?.delivery?.courier?.name ?? 'Assigned courier';
 
   const mapRegion = useMemo<Region>(() => {
-    if (deliveryLocation?.lat && deliveryLocation?.lng) {
+    if (order?.delivery?.location?.lat && order.delivery.location.lng) {
       return {
-        latitude: deliveryLocation.lat,
-        longitude: deliveryLocation.lng,
+        latitude: order.delivery.location.lat,
+        longitude: order.delivery.location.lng,
         latitudeDelta: 0.03,
         longitudeDelta: 0.03,
       } satisfies Region;
     }
 
     return DEFAULT_REGION;
-  }, [deliveryLocation]);
+  }, [order?.delivery?.location?.lat, order?.delivery?.location?.lng]);
 
-  const destinationCoordinate = useMemo<LatLng>(
-    () => ({ latitude: mapRegion.latitude, longitude: mapRegion.longitude }),
-    [mapRegion],
-  );
+  const destinationCoordinate: LatLng = {
+    latitude: mapRegion.latitude,
+    longitude: mapRegion.longitude,
+  };
 
-  const routeCoordinates = useMemo<LatLng[]>(() => {
+  const routeCoordinates: LatLng[] = useMemo(() => {
     const { latitude, longitude } = mapRegion;
     return [
-      { latitude: latitude - 0.018, longitude: longitude - 0.015 },
+      { latitude: latitude - 0.02, longitude: longitude - 0.012 },
       { latitude: latitude - 0.012, longitude: longitude - 0.008 },
-      { latitude: latitude - 0.006, longitude: longitude - 0.003 },
-      { latitude: latitude - 0.001, longitude: longitude + 0.002 },
+      { latitude: latitude - 0.005, longitude: longitude - 0.003 },
+      { latitude: latitude + 0.001, longitude: longitude + 0.002 },
       { latitude: latitude + 0.004, longitude: longitude + 0.006 },
-      { latitude: latitude + 0.008, longitude: longitude + 0.01 },
     ];
   }, [mapRegion]);
 
-  const driverCoordinate = useMemo<LatLng>(() => {
-    if (routeCoordinates.length < 2) {
-      return destinationCoordinate;
-    }
-
-    const totalSegments = routeCoordinates.length - 1;
-    const normalizedProgress = clamp(safeProgress, 0, 0.9999) * totalSegments;
-    const segmentIndex = Math.floor(normalizedProgress);
-    const segmentProgress = normalizedProgress - segmentIndex;
-    const start = routeCoordinates[segmentIndex];
-    const end = routeCoordinates[Math.min(segmentIndex + 1, routeCoordinates.length - 1)];
-
-    return {
-      latitude: start.latitude + (end.latitude - start.latitude) * segmentProgress,
-      longitude: start.longitude + (end.longitude - start.longitude) * segmentProgress,
-    } satisfies LatLng;
-  }, [destinationCoordinate, routeCoordinates, safeProgress]);
-
-  const pulseAnim = useRef(new Animated.Value(0)).current;
-  const timelineAnimations = useMemo(() => steps.map(() => new Animated.Value(0)), [steps]);
-
-  useEffect(() => {
-    const animation = Animated.loop(
-      Animated.sequence([
-        Animated.timing(pulseAnim, {
-          toValue: 1,
-          duration: 1600,
-          easing: Easing.out(Easing.quad),
-          useNativeDriver: true,
-        }),
-        Animated.timing(pulseAnim, {
-          toValue: 0,
-          duration: 0,
-          useNativeDriver: true,
-        }),
-      ]),
-    );
-
-    animation.start();
-    return () => {
-      animation.stop();
-    };
-  }, [pulseAnim]);
-
-  useEffect(() => {
-    timelineAnimations.forEach((value) => value.setValue(0));
-    const animations = timelineAnimations.map((value, index) =>
-      Animated.timing(value, {
-        toValue: 1,
-        duration: 360,
-        delay: index * 100,
-        easing: Easing.out(Easing.cubic),
-        useNativeDriver: true,
-      }),
-    );
-    const controller = Animated.stagger(100, animations);
-    controller.start();
-
-    return () => {
-      controller.stop();
-    };
-  }, [timelineAnimations]);
-
-  const pulseScale = pulseAnim.interpolate({ inputRange: [0, 1], outputRange: [1, 1.9] });
-  const pulseOpacity = pulseAnim.interpolate({ inputRange: [0, 0.7, 1], outputRange: [0.4, 0.15, 0] });
-
-  const restaurantName = order?.restaurant?.name ?? 'Your restaurant';
-  const orderIdLabel = order ? `#${order.orderId}` : 'Live order';
-  const deliveryAddress = order?.delivery?.address ?? 'Your saved address';
-  const addressLabel = order?.delivery?.savedAddress?.label ?? 'Delivery address';
-  const trimmedAddress = deliveryAddress.length > 120 ? `${deliveryAddress.slice(0, 117)}...` : deliveryAddress;
-  const deliveryArea = useMemo(() => {
-    if (addressLabel && addressLabel !== 'Delivery address') {
-      return addressLabel;
-    }
-    const [firstPart] = deliveryAddress.split(',');
-    return firstPart.trim().length ? firstPart.trim() : 'Your area';
-  }, [addressLabel, deliveryAddress]);
-
-  const estimatedWindow = useMemo(() => {
-    if (!order) {
-      return '35-45 min';
-    }
-
-    const itemCount = order.items?.length ?? 0;
-    const base = 28 + Math.min(itemCount * 4, 12);
-    const start = Math.max(18, base - 6);
-    const end = base + 6;
-    return `${start}-${end} min`;
-  }, [order]);
-
-  const orderTotal = order ? formatServerMoney(order.payment?.total) : undefined;
-  const displayedItems = useMemo(() => (order?.items ?? []).slice(0, 3), [order?.items]);
-  const remainingItems = Math.max(0, (order?.items?.length ?? 0) - displayedItems.length);
+  const driverCoordinate: LatLng = routeCoordinates[1] ?? destinationCoordinate;
 
   const handleGoBack = () => {
-    navigation.goBack();
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+    }
   };
 
   const handleCallCourier = () => {};
 
   const handleSeeDetails = () => {
-    if (!order) {
-      return;
-    }
     navigation.navigate('CheckoutOrder', { viewMode: true, order });
   };
 
-  const header = (
-    <View style={styles.heroContainer}>
+  const renderHero = (collapsed: boolean) => (
+    <View style={collapsed ? styles.mapCollapsed : styles.mapExpanded}>
       <MapView
         style={StyleSheet.absoluteFill}
         region={mapRegion}
@@ -371,302 +268,194 @@ const OrderTrackingScreen: React.FC = () => {
         rotateEnabled={false}
         pitchEnabled={false}
         zoomEnabled={false}
-        customMapStyle={mapTheme}
-        showsBuildings={false}
-        showsCompass={false}
         showsPointsOfInterest={false}
+        showsCompass={false}
       >
         <Polyline
           coordinates={routeCoordinates}
-          strokeColor="rgba(216,58,46,0.85)"
-          strokeWidth={5}
+          strokeColor="rgba(255,255,255,0.85)"
+          strokeWidth={4}
           lineCap="round"
           lineJoin="round"
         />
-        <Marker coordinate={driverCoordinate} anchor={{ x: 0.5, y: 0.5 }}>
-          <View style={styles.mapDriverMarkerContainer}>
-            <Animated.View
-              style={[
-                styles.mapDriverPulse,
-                { transform: [{ scale: pulseScale }], opacity: pulseOpacity },
-              ]}
-            />
-            <View style={styles.mapDriverMarker}>
-              <Bike size={18} color="white" />
-            </View>
+        <Marker coordinate={driverCoordinate}>
+          <View style={styles.driverMarker}>
+            <Bike size={16} color="white" />
           </View>
         </Marker>
-        <Marker coordinate={destinationCoordinate} anchor={{ x: 0.5, y: 0.95 }}>
-          <View style={styles.destinationMarker}>
-            <View style={styles.destinationDot} />
-          </View>
+        <Marker coordinate={destinationCoordinate}>
+          <View style={styles.destinationMarker} />
         </Marker>
       </MapView>
 
       <LinearGradient
-        colors={['rgba(11,16,28,0.72)', 'rgba(11,16,28,0.32)', 'rgba(255,255,255,0)']}
+        colors={collapsed ? ['rgba(0,0,0,0.4)', 'transparent'] : ['rgba(0,0,0,0.45)', 'transparent']}
+        style={StyleSheet.absoluteFill}
         start={{ x: 0, y: 0 }}
         end={{ x: 0, y: 1 }}
-        style={StyleSheet.absoluteFill}
       />
 
-      <View style={[styles.heroContent, { paddingTop: insets.top + 12 }]}>
-        <View style={styles.heroTopRow}>
-          <TouchableOpacity onPress={handleGoBack} activeOpacity={0.85} style={styles.heroIconButton}>
-            <ArrowLeft color="white" size={22} />
-          </TouchableOpacity>
-          <View style={styles.heroTitleBlock}>
-            <Text allowFontScaling={false} style={styles.heroEyebrow} numberOfLines={1}>
-              {orderIdLabel}
-            </Text>
-            <Text allowFontScaling={false} style={styles.heroTitle} numberOfLines={2}>
-              {activeStep?.title ?? 'Order in progress'}
-            </Text>
-          </View>
-          <TouchableOpacity onPress={handleCallCourier} activeOpacity={0.85} style={styles.heroIconButton}>
-            <Phone color="white" size={20} />
-          </TouchableOpacity>
-        </View>
-
-        <View style={styles.heroInfoCard}>
-          <View style={styles.heroInfoRow}>
-            <View style={styles.heroEtaPill}>
-              <Clock size={16} color={accentColor} />
-              <Text allowFontScaling={false} style={styles.heroEtaText}>
-                {estimatedWindow}
-              </Text>
-            </View>
-            <View style={styles.heroLocationRow}>
-              <MapPin size={16} color={accentColor} />
-              <Text allowFontScaling={false} style={styles.heroLocationText} numberOfLines={1}>
-                {deliveryArea}
-              </Text>
-            </View>
-          </View>
-          <Text allowFontScaling={false} style={styles.heroDescription}>
-            {activeStep?.description ?? 'We are keeping an eye on your delivery.'}
-          </Text>
-        </View>
+      <View style={[styles.mapTopBar, { paddingTop: insets.top + 10 }]}> 
+        <TouchableOpacity
+          onPress={handleGoBack}
+          activeOpacity={0.85}
+          style={styles.backButton}
+        >
+          <ArrowLeft size={20} color="white" />
+        </TouchableOpacity>
       </View>
+
+      {!collapsed ? (
+        <>
+          <View style={styles.mapLocationCard}>
+            <Text style={styles.locationEyebrow}>Delivering to</Text>
+            <View style={styles.locationRow}>
+              <MapPin size={18} color="white" />
+              <View style={styles.locationTexts}>
+                <Text style={styles.locationTitle}>{deliveryArea}</Text>
+                <Text style={styles.locationSubtitle} numberOfLines={1}>
+                  {deliveryAddress}
+                </Text>
+              </View>
+            </View>
+          </View>
+
+          <View style={styles.courierFloatingCard}>
+            <View style={styles.courierAvatar}>
+              <Bike size={20} color={accentColor} />
+            </View>
+          <View style={styles.courierDetails}>
+            <Text style={styles.courierLabel}>Delivered by</Text>
+            <Text style={styles.courierName}>{courierName}</Text>
+            <View style={styles.courierMetaRow}>
+              <Star size={14} color={accentColor} fill={accentColor} />
+              <Text style={styles.courierMetaText}>
+                {courierRating} • {courierDeliveries} deliveries
+              </Text>
+            </View>
+          </View>
+            <TouchableOpacity
+              style={styles.callPill}
+              activeOpacity={0.85}
+              onPress={handleCallCourier}
+            >
+              <Phone size={18} color="white" />
+            </TouchableOpacity>
+          </View>
+        </>
+      ) : null}
     </View>
   );
 
-  const collapsedHeader = (
-    <LinearGradient colors={[accentColor, '#F0644B']} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.collapsedHeader}>
-      <View style={[styles.collapsedContent, { paddingTop: insets.top + 6 }]}>
-        <TouchableOpacity onPress={handleGoBack} activeOpacity={0.85} style={styles.collapsedIconButton}>
-          <ArrowLeft color="white" size={20} />
-        </TouchableOpacity>
-        <View style={styles.collapsedTexts}>
-          <Text allowFontScaling={false} style={styles.collapsedOrder} numberOfLines={1}>
-            {orderIdLabel}
-          </Text>
-          <Text allowFontScaling={false} style={styles.collapsedTitle} numberOfLines={1}>
-            {activeStep?.title ?? 'Order in progress'}
-          </Text>
-          <Text allowFontScaling={false} style={styles.collapsedMeta} numberOfLines={1}>
-            ETA {estimatedWindow} • {activeStep?.statusLabel ?? 'In progress'}
-          </Text>
-        </View>
-        <TouchableOpacity onPress={handleCallCourier} activeOpacity={0.9} style={styles.collapsedCallButton}>
-          <Phone color={accentColor} size={18} />
-        </TouchableOpacity>
-      </View>
-    </LinearGradient>
-  );
-
   const mainContent = (
-    <View style={styles.sheetContainer}>
-      <View style={styles.sheetHandle} />
-
-      <View style={styles.statusCard}>
-        <View style={styles.statusHeaderRow}>
-          <View>
-            <Text allowFontScaling={false} style={styles.statusEyebrow}>
-              Current status
-            </Text>
-            <Text allowFontScaling={false} style={styles.statusTitle}>
-              {activeStep?.title ?? 'Order in progress'}
-            </Text>
-          </View>
-          <View style={styles.statusEtaChip}>
-            <Clock size={16} color={accentColor} />
-            <Text allowFontScaling={false} style={styles.statusEtaText}>
-              {estimatedWindow}
-            </Text>
+    <ScrollView
+      contentContainerStyle={styles.contentContainer}
+      showsVerticalScrollIndicator={false}
+    >
+      <View style={styles.stepsCard}>
+        <View style={styles.stepsHeader}>
+          <Text style={styles.stepsTitle}>Order Steps</Text>
+          <View style={styles.stepsStatusPill}>
+            <Clock size={14} color="white" />
+            <Text style={styles.stepsStatusText}>In progress</Text>
           </View>
         </View>
-        <Text allowFontScaling={false} style={styles.statusDescription}>
-          {activeStep?.description ?? 'We will notify you as soon as something changes.'}
-        </Text>
-      </View>
-
-      <View style={[styles.timelineCard, styles.sectionSpacing]}>
-        <Text allowFontScaling={false} style={styles.timelineTitle}>
-          Delivery progress
-        </Text>
         {steps.map((step, index) => {
-          const isActive = index === activeIndex;
-          const isCompleted = index < activeIndex || (steps.length - 1 === index && step.completed);
           const isLast = index === steps.length - 1;
-          const animation = timelineAnimations[index];
-          const animatedStyle: Animated.WithAnimatedObject<ViewStyle> | undefined = animation
-            ? {
-                opacity: animation,
-                transform: [
-                  {
-                    translateY: animation.interpolate({ inputRange: [0, 1], outputRange: [16, 0] }),
-                  },
-                ],
-              }
-            : undefined;
+          const dotStyle = [styles.stepDot];
+          if (step.state === 'completed') {
+            dotStyle.push(styles.stepDotCompleted);
+          } else if (step.state === 'active') {
+            dotStyle.push(styles.stepDotActive);
+          }
+
+          const lineStyle = [styles.stepLine];
+          if (step.state !== 'pending') {
+            lineStyle.push(styles.stepLineActive);
+          }
 
           return (
-            <Animated.View
-              key={`${step.key}-${index}`}
-              style={[
-                styles.timelineRow,
-                isLast && styles.timelineRowLast,
-                animatedStyle,
-              ]}
-            >
-              <View style={styles.timelineIndicator}>
+            <View key={`${step.key}-${index}`} style={[styles.stepRow, !isLast && styles.stepRowDivider]}>
+              <View style={styles.stepTimeline}>
+                <View style={dotStyle} />
+                {!isLast ? <View style={lineStyle} /> : null}
+              </View>
+              <View style={styles.stepTexts}>
+                <Text style={styles.stepStage}>Step {index + 1}</Text>
+                <Text style={styles.stepTitle}>{step.title}</Text>
+                <Text style={styles.stepDescription}>{step.description}</Text>
+              </View>
+              <View style={styles.stepMeta}>
                 <View
                   style={[
-                    styles.timelineDot,
-                    isCompleted && styles.timelineDotCompleted,
-                    isActive && !isCompleted && styles.timelineDotActive,
+                    styles.stepStatusBadge,
+                    step.state === 'completed' && styles.stepStatusBadgeCompleted,
+                    step.state === 'active' && styles.stepStatusBadgeActive,
                   ]}
                 >
-                  {isCompleted ? <CheckCircle2 size={14} color="white" /> : null}
-                </View>
-                {!isLast ? (
-                  <View
+                  <Text
                     style={[
-                      styles.timelineConnector,
-                      (isCompleted || isActive) && styles.timelineConnectorActive,
+                      styles.stepStatusLabel,
+                      step.state !== 'pending' && styles.stepStatusLabelContrast,
                     ]}
-                  />
-                ) : null}
-              </View>
-              <View style={styles.timelineContent}>
-                <Text allowFontScaling={false} style={styles.timelineStepTitle}>
-                  {step.title}
-                </Text>
-                <Text allowFontScaling={false} style={styles.timelineStepDescription}>
-                  {step.description}
-                </Text>
-                {step.statusLabel ? (
-                  <Text allowFontScaling={false} style={styles.timelineStepLabel}>
-                    {step.statusLabel}
+                  >
+                    {step.statusText}
                   </Text>
-                ) : null}
+                </View>
+                <Text style={styles.stepEta}>{step.etaLabel}</Text>
               </View>
-            </Animated.View>
+            </View>
           );
         })}
       </View>
 
-      <View style={[styles.courierCard, styles.sectionSpacing]}>
-        <View style={styles.courierBadge}>
-          <Bike size={22} color={accentColor} />
-        </View>
-        <View style={styles.courierInfo}>
-          <Text allowFontScaling={false} style={styles.courierLabel}>
-            Courier
-          </Text>
-          <Text allowFontScaling={false} style={styles.courierName} numberOfLines={1}>
-            {order?.delivery?.courier?.name ?? 'Assigned courier'}
-          </Text>
-          <Text allowFontScaling={false} style={styles.courierStatus} numberOfLines={1}>
-            {activeStep?.statusLabel ?? 'In progress'}
-          </Text>
-        </View>
-        <TouchableOpacity onPress={handleCallCourier} activeOpacity={0.9} style={styles.courierCallButton}>
-          <Phone size={18} color="white" />
-          <Text allowFontScaling={false} style={styles.courierCallLabel}>
-            Call
-          </Text>
-        </TouchableOpacity>
-      </View>
-
-      <View style={[styles.destinationCard, styles.sectionSpacing]}>
-        <View style={styles.destinationHeader}>
-          <MapPin size={18} color={accentColor} />
-          <Text allowFontScaling={false} style={styles.destinationTitle}>
-            Delivering to
-          </Text>
-        </View>
-        <Text allowFontScaling={false} style={styles.destinationAddress}>
-          {trimmedAddress}
-        </Text>
-      </View>
-
-      <View style={[styles.orderCard, styles.sectionSpacing]}>
-        <View style={styles.orderHeader}>
-          <View>
-            <Text allowFontScaling={false} style={styles.orderTitle}>
-              Order summary
-            </Text>
-            <Text allowFontScaling={false} style={styles.orderSubtitle}>
-              {restaurantName}
-            </Text>
+      <View style={styles.summaryCard}>
+        <View style={styles.summaryHeader}>
+          <Text style={styles.summaryTitle}>My Order</Text>
+          <View style={styles.summaryBadge}>
+            <Text style={styles.summaryBadgeText}>{order?.restaurant?.name ?? 'Your restaurant'}</Text>
           </View>
-          {orderTotal ? (
-            <Text allowFontScaling={false} style={styles.orderTotal}>
-              {orderTotal}
-            </Text>
-          ) : null}
         </View>
 
-        {displayedItems.length > 0 ? (
-          <View style={styles.orderItems}>
-            {displayedItems.map((item, index) => (
+        <View style={styles.summaryItems}>
+          {order?.items?.map((item, index) => {
+            const isLast = index === (order?.items?.length ?? 0) - 1;
+            return (
               <View
-                key={`${item.menuItem?.id ?? item.name ?? index}-${index}`}
+                key={`${item.menuItem?.id ?? index}-${index}`}
                 style={[
-                  styles.orderItemRow,
-                  index === displayedItems.length - 1 && styles.orderItemRowLast,
+                  styles.summaryItemRow,
+                  !isLast && styles.summaryItemRowSpacing,
                 ]}
               >
-                <Text allowFontScaling={false} style={styles.orderItemQuantity}>
-                  {item.quantity ?? 1}x
-                </Text>
-                <Text allowFontScaling={false} style={styles.orderItemName} numberOfLines={1}>
-                  {item.menuItem?.name ?? item.name ?? 'Menu item'}
-                </Text>
-              </View>
-            ))}
-            {remainingItems > 0 ? (
-              <Text allowFontScaling={false} style={styles.orderMoreLabel}>
-                +{remainingItems} more item{remainingItems > 1 ? 's' : ''}
+              <Text style={styles.summaryItemQuantity}>{item.quantity ?? 1}x</Text>
+              <Text style={styles.summaryItemName} numberOfLines={1}>
+                {item.menuItem?.name ?? item.name ?? 'Menu item'}
               </Text>
-            ) : null}
-          </View>
-        ) : (
-          <Text allowFontScaling={false} style={styles.emptyItemsText}>
-            Your order details will appear here once confirmed.
-          </Text>
-        )}
+              </View>
+            );
+          })}
+        </View>
 
-        <TouchableOpacity onPress={handleSeeDetails} activeOpacity={0.9} style={styles.orderDetailsButton}>
-          <Text allowFontScaling={false} style={styles.orderDetailsLabel}>
-            See details
-          </Text>
-        </TouchableOpacity>
+        <View style={styles.summaryFooter}>
+          {orderTotal ? <Text style={styles.summaryTotal}>{orderTotal}</Text> : null}
+          <TouchableOpacity onPress={handleSeeDetails} activeOpacity={0.85} style={styles.summaryDetailsButton}>
+            <Text style={styles.summaryDetailsText}>See details</Text>
+          </TouchableOpacity>
+        </View>
       </View>
-    </View>
+    </ScrollView>
   );
 
   return (
     <View style={styles.screen}>
       <MainLayout
         showFooter={false}
-        customHeader={header}
-        collapsedHeader={collapsedHeader}
+        customHeader={renderHero(false)}
+        collapsedHeader={renderHero(true)}
         mainContent={mainContent}
         headerMaxHeight={360}
-        headerMinHeight={120}
+        headerMinHeight={160}
         enableHeaderCollapse
         enforceResponsiveHeaderSize={false}
       />
@@ -681,294 +470,99 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: softBackground,
   },
-  heroContainer: {
+  mapExpanded: {
     flex: 1,
     borderBottomLeftRadius: 28,
     borderBottomRightRadius: 28,
     overflow: 'hidden',
   },
-  heroContent: {
+  mapCollapsed: {
     flex: 1,
-    justifyContent: 'space-between',
-    paddingHorizontal: 20,
-    paddingBottom: 24,
+    overflow: 'hidden',
   },
-  heroTopRow: {
+  mapTopBar: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    paddingHorizontal: 20,
     flexDirection: 'row',
+    justifyContent: 'space-between',
     alignItems: 'center',
   },
-  heroIconButton: {
+  backButton: {
     width: 44,
     height: 44,
     borderRadius: 16,
-    backgroundColor: 'rgba(255,255,255,0.18)',
+    backgroundColor: 'rgba(0,0,0,0.35)',
     alignItems: 'center',
     justifyContent: 'center',
   },
-  heroTitleBlock: {
-    flex: 1,
-    marginHorizontal: 16,
-  },
-  heroEyebrow: {
-    fontSize: 12,
-    textTransform: 'uppercase',
-    letterSpacing: 1,
-    color: 'rgba(255,255,255,0.7)',
-    marginBottom: 4,
-    fontWeight: '600',
-  },
-  heroTitle: {
-    fontSize: 22,
-    fontWeight: '700',
-    color: 'white',
-  },
-  heroInfoCard: {
-    backgroundColor: 'rgba(255,255,255,0.94)',
-    borderRadius: 22,
-    padding: 18,
-  },
-  heroInfoRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  heroEtaPill: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: accentMuted,
-    borderRadius: 999,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-  },
-  heroEtaText: {
-    marginLeft: 6,
-    fontSize: 13,
-    fontWeight: '600',
-    color: accentColor,
-  },
-  heroLocationRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    backgroundColor: 'rgba(216,58,46,0.1)',
-    borderRadius: 999,
-  },
-  heroLocationText: {
-    marginLeft: 6,
-    fontSize: 13,
-    fontWeight: '600',
-    color: heroText,
-  },
-  heroDescription: {
-    marginTop: 16,
-    fontSize: 14,
-    lineHeight: 20,
-    color: heroText,
-    fontWeight: '500',
-  },
-  mapDriverMarkerContainer: {
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  mapDriverPulse: {
+  mapLocationCard: {
     position: 'absolute',
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    backgroundColor: 'rgba(216,58,46,0.25)',
-  },
-  mapDriverMarker: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    alignItems: 'center',
-    justifyContent: 'center',
+    left: 20,
+    right: 20,
+    bottom: 140,
     backgroundColor: accentColor,
-    shadowColor: accentColor,
-    shadowOpacity: 0.35,
-    shadowRadius: 12,
+    borderRadius: 20,
+    padding: 18,
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowRadius: 10,
     shadowOffset: { width: 0, height: 6 },
     elevation: 6,
   },
-  destinationMarker: {
-    width: 18,
-    height: 18,
-    borderRadius: 9,
-    borderWidth: 3,
-    borderColor: softSurface,
-    backgroundColor: accentColor,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  destinationDot: {
-    width: 6,
-    height: 6,
-    borderRadius: 3,
-    backgroundColor: softSurface,
-  },
-  sheetContainer: {
-    flex: 1,
-    paddingHorizontal: 20,
-    paddingTop: 16,
-    paddingBottom: 40,
-  },
-  sectionSpacing: {
-    marginTop: 18,
-  },
-  sheetHandle: {
-    alignSelf: 'center',
-    width: 44,
-    height: 4,
-    borderRadius: 999,
-    backgroundColor: '#D1D5DB',
-    marginBottom: 4,
-  },
-  statusCard: {
-    backgroundColor: softSurface,
-    borderRadius: 22,
-    padding: 20,
-    shadowColor: '#0F172A',
-    shadowOpacity: 0.05,
-    shadowRadius: 12,
-    shadowOffset: { width: 0, height: 8 },
-    elevation: 4,
-  },
-  statusHeaderRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-  },
-  statusEyebrow: {
+  locationEyebrow: {
+    color: 'rgba(255,255,255,0.75)',
     fontSize: 12,
-    textTransform: 'uppercase',
     letterSpacing: 1,
-    color: accentColor,
+    textTransform: 'uppercase',
+    marginBottom: 10,
     fontWeight: '600',
   },
-  statusTitle: {
-    marginTop: 6,
-    fontSize: 20,
-    fontWeight: '700',
-    color: heroText,
-  },
-  statusEtaChip: {
+  locationRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: accentMuted,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 999,
   },
-  statusEtaText: {
-    marginLeft: 6,
-    fontSize: 13,
-    fontWeight: '600',
-    color: accentColor,
+  locationTexts: {
+    marginLeft: 12,
+    flex: 1,
   },
-  statusDescription: {
-    marginTop: 14,
+  locationTitle: {
+    color: 'white',
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  locationSubtitle: {
+    color: 'rgba(255,255,255,0.85)',
+    marginTop: 4,
     fontSize: 14,
-    lineHeight: 20,
-    color: secondaryText,
   },
-  timelineCard: {
+  courierFloatingCard: {
+    position: 'absolute',
+    left: 20,
+    right: 20,
+    bottom: 28,
+    flexDirection: 'row',
+    alignItems: 'center',
     backgroundColor: softSurface,
-    borderRadius: 22,
-    paddingVertical: 16,
-    paddingHorizontal: 20,
+    borderRadius: 18,
+    padding: 16,
     shadowColor: '#0F172A',
-    shadowOpacity: 0.04,
+    shadowOpacity: 0.08,
     shadowRadius: 10,
     shadowOffset: { width: 0, height: 6 },
-    elevation: 3,
+    elevation: 5,
   },
-  timelineTitle: {
-    fontSize: 16,
-    fontWeight: '700',
-    color: heroText,
-    marginBottom: 12,
-  },
-  timelineRow: {
-    flexDirection: 'row',
-    marginBottom: 16,
-  },
-  timelineRowLast: {
-    marginBottom: 0,
-  },
-  timelineIndicator: {
-    alignItems: 'center',
-    marginRight: 16,
-  },
-  timelineDot: {
-    width: 26,
-    height: 26,
-    borderRadius: 13,
-    backgroundColor: '#E5E7EB',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  timelineDotActive: {
-    backgroundColor: 'rgba(216,58,46,0.15)',
-    borderWidth: 2,
-    borderColor: accentColor,
-  },
-  timelineDotCompleted: {
-    backgroundColor: accentColor,
-  },
-  timelineConnector: {
-    flex: 1,
-    width: 2,
-    backgroundColor: '#E5E7EB',
-    marginTop: 4,
-  },
-  timelineConnectorActive: {
-    backgroundColor: accentColor,
-  },
-  timelineContent: {
-    flex: 1,
-  },
-  timelineStepTitle: {
-    fontSize: 15,
-    fontWeight: '600',
-    color: heroText,
-  },
-  timelineStepDescription: {
-    marginTop: 4,
-    fontSize: 13,
-    lineHeight: 18,
-    color: secondaryText,
-  },
-  timelineStepLabel: {
-    marginTop: 6,
-    fontSize: 12,
-    fontWeight: '600',
-    color: accentColor,
-    textTransform: 'uppercase',
-    letterSpacing: 1,
-  },
-  courierCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: softSurface,
-    borderRadius: 20,
-    paddingHorizontal: 18,
-    paddingVertical: 16,
-    shadowColor: '#0F172A',
-    shadowOpacity: 0.04,
-    shadowRadius: 8,
-    shadowOffset: { width: 0, height: 6 },
-    elevation: 3,
-  },
-  courierBadge: {
-    width: 48,
-    height: 48,
+  courierAvatar: {
+    width: 52,
+    height: 52,
     borderRadius: 16,
-    backgroundColor: accentMuted,
+    backgroundColor: '#FCE7E4',
     alignItems: 'center',
     justifyContent: 'center',
   },
-  courierInfo: {
+  courierDetails: {
     flex: 1,
     marginHorizontal: 16,
   },
@@ -976,182 +570,257 @@ const styles = StyleSheet.create({
     fontSize: 12,
     textTransform: 'uppercase',
     letterSpacing: 1,
-    color: secondaryText,
+    color: textSecondary,
     fontWeight: '600',
   },
   courierName: {
     marginTop: 4,
-    fontSize: 16,
+    fontSize: 18,
     fontWeight: '700',
-    color: heroText,
+    color: textPrimary,
   },
-  courierStatus: {
-    marginTop: 4,
+  courierMetaRow: {
+    marginTop: 6,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  courierMetaText: {
+    marginLeft: 6,
+    color: textSecondary,
     fontSize: 13,
-    color: secondaryText,
   },
-  courierCallButton: {
+  callPill: {
+    width: 48,
+    height: 48,
+    borderRadius: 16,
+    backgroundColor: accentColor,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  driverMarker: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: accentColor,
+    borderWidth: 3,
+    borderColor: 'white',
+  },
+  destinationMarker: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    backgroundColor: 'white',
+    borderWidth: 4,
+    borderColor: accentColor,
+  },
+  contentContainer: {
+    paddingHorizontal: 20,
+    paddingTop: 32,
+    paddingBottom: 60,
+  },
+  stepsCard: {
+    backgroundColor: softSurface,
+    borderRadius: 24,
+    padding: 20,
+    shadowColor: '#0F172A',
+    shadowOpacity: 0.05,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 3,
+    marginBottom: 20,
+  },
+  stepsHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 18,
+  },
+  stepsTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: textPrimary,
+  },
+  stepsStatusPill: {
     flexDirection: 'row',
     alignItems: 'center',
     backgroundColor: accentColor,
     borderRadius: 999,
-    paddingHorizontal: 18,
-    paddingVertical: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 6,
   },
-  courierCallLabel: {
-    fontSize: 14,
-    fontWeight: '600',
+  stepsStatusText: {
     color: 'white',
     marginLeft: 8,
+    fontSize: 13,
+    fontWeight: '600',
   },
-  destinationCard: {
-    backgroundColor: softSurface,
-    borderRadius: 20,
-    padding: 18,
-    shadowColor: '#0F172A',
-    shadowOpacity: 0.04,
-    shadowRadius: 8,
-    shadowOffset: { width: 0, height: 4 },
-    elevation: 2,
-  },
-  destinationHeader: {
+  stepRow: {
     flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingBottom: 18,
+  },
+  stepRowDivider: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: borderColor,
+    marginBottom: 18,
+  },
+  stepTimeline: {
+    width: 34,
     alignItems: 'center',
   },
-  destinationTitle: {
-    marginLeft: 8,
-    fontSize: 14,
-    fontWeight: '700',
-    color: heroText,
+  stepDot: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    borderColor: '#E5E7EB',
+    backgroundColor: '#FFFFFF',
   },
-  destinationAddress: {
-    marginTop: 10,
+  stepDotCompleted: {
+    backgroundColor: accentColor,
+    borderColor: accentColor,
+  },
+  stepDotActive: {
+    borderColor: accentColor,
+  },
+  stepLine: {
+    position: 'absolute',
+    top: 22,
+    bottom: -18,
+    width: 2,
+    backgroundColor: '#E5E7EB',
+  },
+  stepLineActive: {
+    backgroundColor: accentColor,
+  },
+  stepTexts: {
+    flex: 1,
+    paddingRight: 12,
+  },
+  stepStage: {
+    fontSize: 12,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    color: accentColor,
+    fontWeight: '600',
+  },
+  stepTitle: {
+    marginTop: 4,
+    fontSize: 16,
+    fontWeight: '600',
+    color: textPrimary,
+  },
+  stepDescription: {
+    marginTop: 6,
     fontSize: 14,
     lineHeight: 20,
-    color: secondaryText,
+    color: textSecondary,
   },
-  orderCard: {
+  stepMeta: {
+    alignItems: 'flex-end',
+    width: 90,
+  },
+  stepStatusBadge: {
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    borderRadius: 999,
+    backgroundColor: '#F1F5F9',
+  },
+  stepStatusBadgeCompleted: {
+    backgroundColor: '#DCF0EA',
+  },
+  stepStatusBadgeActive: {
+    backgroundColor: accentColor,
+  },
+  stepStatusLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: accentColor,
+  },
+  stepStatusLabelContrast: {
+    color: 'white',
+  },
+  stepEta: {
+    marginTop: 6,
+    fontSize: 13,
+    color: '#EF4444',
+    fontWeight: '600',
+  },
+  summaryCard: {
     backgroundColor: softSurface,
-    borderRadius: 22,
+    borderRadius: 24,
     padding: 20,
     shadowColor: '#0F172A',
     shadowOpacity: 0.05,
-    shadowRadius: 12,
+    shadowRadius: 10,
     shadowOffset: { width: 0, height: 6 },
-    elevation: 4,
+    elevation: 3,
   },
-  orderHeader: {
+  summaryHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 18,
+  },
+  summaryTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: textPrimary,
+  },
+  summaryBadge: {
+    backgroundColor: '#FDE6E3',
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+  },
+  summaryBadgeText: {
+    color: accentColor,
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  summaryItems: {
+    marginBottom: 16,
+  },
+  summaryItemRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  summaryItemRowSpacing: {
+    marginBottom: 12,
+  },
+  summaryItemQuantity: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: accentColor,
+    marginRight: 12,
+  },
+  summaryItemName: {
+    flex: 1,
+    fontSize: 15,
+    color: textPrimary,
+  },
+  summaryFooter: {
+    marginTop: 24,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
   },
-  orderTitle: {
-    fontSize: 16,
+  summaryTotal: {
+    fontSize: 18,
     fontWeight: '700',
-    color: heroText,
+    color: textPrimary,
   },
-  orderSubtitle: {
-    marginTop: 4,
-    fontSize: 13,
-    color: secondaryText,
-  },
-  orderTotal: {
-    fontSize: 16,
-    fontWeight: '700',
-    color: accentColor,
-  },
-  orderItems: {
-    marginTop: 16,
-  },
-  orderItemRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 12,
-  },
-  orderItemRowLast: {
-    marginBottom: 0,
-  },
-  orderItemQuantity: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: accentColor,
-    marginRight: 10,
-  },
-  orderItemName: {
-    flex: 1,
-    fontSize: 14,
-    color: heroText,
-    fontWeight: '500',
-  },
-  orderMoreLabel: {
-    marginTop: 4,
-    fontSize: 13,
-    color: secondaryText,
-  },
-  emptyItemsText: {
-    marginTop: 16,
-    fontSize: 14,
-    color: secondaryText,
-  },
-  orderDetailsButton: {
-    marginTop: 20,
-    backgroundColor: heroText,
+  summaryDetailsButton: {
     borderRadius: 16,
-    paddingVertical: 14,
-    alignItems: 'center',
-  },
-  orderDetailsLabel: {
-    fontSize: 15,
-    fontWeight: '600',
-    color: 'white',
-  },
-  collapsedHeader: {
-    flex: 1,
-    width: '100%',
-    height: '100%',
     paddingHorizontal: 20,
-    paddingBottom: 12,
+    paddingVertical: 12,
+    backgroundColor: accentColor,
   },
-  collapsedContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  collapsedIconButton: {
-    height: 40,
-    width: 40,
-    borderRadius: 16,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: 'rgba(255,255,255,0.18)',
-  },
-  collapsedTexts: {
-    flex: 1,
-    marginHorizontal: 14,
-  },
-  collapsedOrder: {
-    fontSize: 12,
-    fontWeight: '600',
-    letterSpacing: 1.2,
-    textTransform: 'uppercase',
-    color: 'rgba(255,255,255,0.72)',
-  },
-  collapsedTitle: {
-    marginTop: 4,
-    fontSize: 16,
-    fontWeight: '700',
+  summaryDetailsText: {
     color: 'white',
-  },
-  collapsedMeta: {
-    marginTop: 4,
-    fontSize: 13,
-    color: 'rgba(255,255,255,0.85)',
-  },
-  collapsedCallButton: {
-    height: 40,
-    width: 40,
-    borderRadius: 16,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: softSurface,
+    fontSize: 14,
+    fontWeight: '600',
   },
 });

--- a/src/screens/OrderTracking.tsx
+++ b/src/screens/OrderTracking.tsx
@@ -18,15 +18,14 @@ import MainLayout from '~/layouts/MainLayout';
 
 const accentColor = '#D83A2E';
 const accentMuted = '#FBE5E1';
-const heroDark = '#1A253A';
-const surfaceColor = '#FFFFFF';
+const heroText = '#0F172A';
+const softSurface = '#FFFFFF';
 const softBackground = '#F5F6FA';
-const headingText = '#1F2937';
-const mutedText = '#6B7280';
+const secondaryText = '#6B7280';
 
 const mapTheme: MapStyleElement[] = [
-  { elementType: 'geometry', stylers: [{ color: '#E8ECF4' }] },
-  { elementType: 'labels.text.fill', stylers: [{ color: '#425466' }] },
+  { elementType: 'geometry', stylers: [{ color: '#E7ECF5' }] },
+  { elementType: 'labels.text.fill', stylers: [{ color: '#2E3A4A' }] },
   { elementType: 'labels.text.stroke', stylers: [{ color: '#FFFFFF' }] },
   {
     featureType: 'poi',
@@ -56,7 +55,7 @@ const mapTheme: MapStyleElement[] = [
   {
     featureType: 'water',
     elementType: 'geometry',
-    stylers: [{ color: '#C4DAF7' }],
+    stylers: [{ color: '#C5DAF7' }],
   },
 ];
 
@@ -304,13 +303,13 @@ const OrderTrackingScreen: React.FC = () => {
     const animations = timelineAnimations.map((value, index) =>
       Animated.timing(value, {
         toValue: 1,
-        duration: 380,
-        delay: index * 90,
+        duration: 360,
+        delay: index * 100,
         easing: Easing.out(Easing.cubic),
         useNativeDriver: true,
       }),
     );
-    const controller = Animated.stagger(90, animations);
+    const controller = Animated.stagger(100, animations);
     controller.start();
 
     return () => {
@@ -319,13 +318,13 @@ const OrderTrackingScreen: React.FC = () => {
   }, [timelineAnimations]);
 
   const pulseScale = pulseAnim.interpolate({ inputRange: [0, 1], outputRange: [1, 1.9] });
-  const pulseOpacity = pulseAnim.interpolate({ inputRange: [0, 0.7, 1], outputRange: [0.3, 0.15, 0] });
+  const pulseOpacity = pulseAnim.interpolate({ inputRange: [0, 0.7, 1], outputRange: [0.4, 0.15, 0] });
 
   const restaurantName = order?.restaurant?.name ?? 'Your restaurant';
   const orderIdLabel = order ? `#${order.orderId}` : 'Live order';
   const deliveryAddress = order?.delivery?.address ?? 'Your saved address';
   const addressLabel = order?.delivery?.savedAddress?.label ?? 'Delivery address';
-  const trimmedAddress = deliveryAddress.length > 90 ? `${deliveryAddress.slice(0, 87)}...` : deliveryAddress;
+  const trimmedAddress = deliveryAddress.length > 120 ? `${deliveryAddress.slice(0, 117)}...` : deliveryAddress;
   const deliveryArea = useMemo(() => {
     if (addressLabel && addressLabel !== 'Delivery address') {
       return addressLabel;
@@ -364,79 +363,92 @@ const OrderTrackingScreen: React.FC = () => {
   };
 
   const header = (
-    <LinearGradient colors={[accentColor, '#F0644B']} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.headerGradient}>
-      <View style={[styles.headerTopRow, { paddingTop: insets.top + 12 }]}>
-        <TouchableOpacity onPress={handleGoBack} activeOpacity={0.85} style={styles.headerIconButton}>
-          <ArrowLeft color="white" size={22} />
-        </TouchableOpacity>
-        <View style={styles.headerLocation}>
-          <Text allowFontScaling={false} style={styles.headerLocationLabel} numberOfLines={1}>
-            Delivering to
-          </Text>
-          <Text allowFontScaling={false} style={styles.headerLocationValue} numberOfLines={1}>
-            {deliveryArea}
-          </Text>
-        </View>
-        <TouchableOpacity onPress={handleCallCourier} activeOpacity={0.85} style={styles.headerCallButton}>
-          <Phone color={accentColor} size={18} />
-        </TouchableOpacity>
-      </View>
-
-      <View style={styles.headerMapCard}>
-        <View style={styles.headerEtaChip}>
-          <Clock size={16} color={accentColor} />
-          <Text allowFontScaling={false} style={styles.headerEtaText}>
-            {estimatedWindow}
-          </Text>
-        </View>
-        <View style={styles.mapWrapper}>
-          <MapView
-            style={StyleSheet.absoluteFill}
-            region={mapRegion}
-            scrollEnabled={false}
-            rotateEnabled={false}
-            pitchEnabled={false}
-            zoomEnabled={false}
-            customMapStyle={mapTheme}
-            showsBuildings={false}
-            showsCompass={false}
-            showsPointsOfInterest={false}
-          >
-            <Polyline
-              coordinates={routeCoordinates}
-              strokeColor="rgba(216,58,46,0.9)"
-              strokeWidth={5}
-              lineCap="round"
-              lineJoin="round"
+    <View style={styles.heroContainer}>
+      <MapView
+        style={StyleSheet.absoluteFill}
+        region={mapRegion}
+        scrollEnabled={false}
+        rotateEnabled={false}
+        pitchEnabled={false}
+        zoomEnabled={false}
+        customMapStyle={mapTheme}
+        showsBuildings={false}
+        showsCompass={false}
+        showsPointsOfInterest={false}
+      >
+        <Polyline
+          coordinates={routeCoordinates}
+          strokeColor="rgba(216,58,46,0.85)"
+          strokeWidth={5}
+          lineCap="round"
+          lineJoin="round"
+        />
+        <Marker coordinate={driverCoordinate} anchor={{ x: 0.5, y: 0.5 }}>
+          <View style={styles.mapDriverMarkerContainer}>
+            <Animated.View
+              style={[
+                styles.mapDriverPulse,
+                { transform: [{ scale: pulseScale }], opacity: pulseOpacity },
+              ]}
             />
-            <Marker coordinate={driverCoordinate} anchor={{ x: 0.5, y: 0.5 }}>
-              <View style={styles.mapDriverMarkerContainer}>
-                <Animated.View
-                  style={[
-                    styles.mapDriverPulse,
-                    { transform: [{ scale: pulseScale }], opacity: pulseOpacity },
-                  ]}
-                />
-                <View style={styles.mapDriverMarker}>
-                  <Bike size={18} color="white" />
-                </View>
-              </View>
-            </Marker>
-            <Marker coordinate={destinationCoordinate} anchor={{ x: 0.5, y: 0.95 }}>
-              <View style={styles.destinationMarker}>
-                <View style={styles.destinationDot} />
-              </View>
-            </Marker>
-          </MapView>
+            <View style={styles.mapDriverMarker}>
+              <Bike size={18} color="white" />
+            </View>
+          </View>
+        </Marker>
+        <Marker coordinate={destinationCoordinate} anchor={{ x: 0.5, y: 0.95 }}>
+          <View style={styles.destinationMarker}>
+            <View style={styles.destinationDot} />
+          </View>
+        </Marker>
+      </MapView>
+
+      <LinearGradient
+        colors={['rgba(11,16,28,0.72)', 'rgba(11,16,28,0.32)', 'rgba(255,255,255,0)']}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 0, y: 1 }}
+        style={StyleSheet.absoluteFill}
+      />
+
+      <View style={[styles.heroContent, { paddingTop: insets.top + 12 }]}>
+        <View style={styles.heroTopRow}>
+          <TouchableOpacity onPress={handleGoBack} activeOpacity={0.85} style={styles.heroIconButton}>
+            <ArrowLeft color="white" size={22} />
+          </TouchableOpacity>
+          <View style={styles.heroTitleBlock}>
+            <Text allowFontScaling={false} style={styles.heroEyebrow} numberOfLines={1}>
+              {orderIdLabel}
+            </Text>
+            <Text allowFontScaling={false} style={styles.heroTitle} numberOfLines={2}>
+              {activeStep?.title ?? 'Order in progress'}
+            </Text>
+          </View>
+          <TouchableOpacity onPress={handleCallCourier} activeOpacity={0.85} style={styles.heroIconButton}>
+            <Phone color="white" size={20} />
+          </TouchableOpacity>
         </View>
-        <View style={styles.headerDestinationRow}>
-          <MapPin size={16} color={accentColor} />
-          <Text allowFontScaling={false} style={styles.headerDestinationText} numberOfLines={2}>
-            {trimmedAddress}
+
+        <View style={styles.heroInfoCard}>
+          <View style={styles.heroInfoRow}>
+            <View style={styles.heroEtaPill}>
+              <Clock size={16} color={accentColor} />
+              <Text allowFontScaling={false} style={styles.heroEtaText}>
+                {estimatedWindow}
+              </Text>
+            </View>
+            <View style={styles.heroLocationRow}>
+              <MapPin size={16} color={accentColor} />
+              <Text allowFontScaling={false} style={styles.heroLocationText} numberOfLines={1}>
+                {deliveryArea}
+              </Text>
+            </View>
+          </View>
+          <Text allowFontScaling={false} style={styles.heroDescription}>
+            {activeStep?.description ?? 'We are keeping an eye on your delivery.'}
           </Text>
         </View>
       </View>
-    </LinearGradient>
+    </View>
   );
 
   const collapsedHeader = (
@@ -464,42 +476,60 @@ const OrderTrackingScreen: React.FC = () => {
   );
 
   const mainContent = (
-    <View style={styles.contentContainer}>
-      <View style={styles.timelineCard}>
-        <View style={styles.timelineHeader}>
+    <View style={styles.sheetContainer}>
+      <View style={styles.sheetHandle} />
+
+      <View style={styles.statusCard}>
+        <View style={styles.statusHeaderRow}>
           <View>
-            <Text allowFontScaling={false} style={styles.timelineTitle}>
-              Order Steps
+            <Text allowFontScaling={false} style={styles.statusEyebrow}>
+              Current status
             </Text>
-            <Text allowFontScaling={false} style={styles.timelineSubtitle}>
-              {restaurantName}
+            <Text allowFontScaling={false} style={styles.statusTitle}>
+              {activeStep?.title ?? 'Order in progress'}
             </Text>
           </View>
-          <View style={styles.timelineStepChip}>
-            <Text allowFontScaling={false} style={styles.timelineStepText}>
-              Step {activeIndex + 1} of {steps.length}
+          <View style={styles.statusEtaChip}>
+            <Clock size={16} color={accentColor} />
+            <Text allowFontScaling={false} style={styles.statusEtaText}>
+              {estimatedWindow}
             </Text>
           </View>
         </View>
+        <Text allowFontScaling={false} style={styles.statusDescription}>
+          {activeStep?.description ?? 'We will notify you as soon as something changes.'}
+        </Text>
+      </View>
 
+      <View style={[styles.timelineCard, styles.sectionSpacing]}>
+        <Text allowFontScaling={false} style={styles.timelineTitle}>
+          Delivery progress
+        </Text>
         {steps.map((step, index) => {
           const isActive = index === activeIndex;
           const isCompleted = index < activeIndex || (steps.length - 1 === index && step.completed);
           const isLast = index === steps.length - 1;
-          const timelineValue = timelineAnimations[index];
-          const animatedStyle: Animated.WithAnimatedObject<ViewStyle> | undefined = timelineValue
+          const animation = timelineAnimations[index];
+          const animatedStyle: Animated.WithAnimatedObject<ViewStyle> | undefined = animation
             ? {
-                opacity: timelineValue,
+                opacity: animation,
                 transform: [
                   {
-                    translateY: timelineValue.interpolate({ inputRange: [0, 1], outputRange: [18, 0] }),
+                    translateY: animation.interpolate({ inputRange: [0, 1], outputRange: [16, 0] }),
                   },
                 ],
               }
             : undefined;
 
           return (
-            <Animated.View key={`${step.key}-${index}`} style={[styles.timelineRow, animatedStyle]}>
+            <Animated.View
+              key={`${step.key}-${index}`}
+              style={[
+                styles.timelineRow,
+                isLast && styles.timelineRowLast,
+                animatedStyle,
+              ]}
+            >
               <View style={styles.timelineIndicator}>
                 <View
                   style={[
@@ -512,42 +542,74 @@ const OrderTrackingScreen: React.FC = () => {
                 </View>
                 {!isLast ? (
                   <View
-                    style={[styles.timelineConnector, (isCompleted || isActive) && styles.timelineConnectorActive]}
+                    style={[
+                      styles.timelineConnector,
+                      (isCompleted || isActive) && styles.timelineConnectorActive,
+                    ]}
                   />
                 ) : null}
               </View>
               <View style={styles.timelineContent}>
-                <Text
-                  allowFontScaling={false}
-                  style={[styles.timelineRowTitle, { color: isActive ? accentColor : headingText }]}
-                >
+                <Text allowFontScaling={false} style={styles.timelineStepTitle}>
                   {step.title}
                 </Text>
-                <Text allowFontScaling={false} style={styles.timelineDescription}>
+                <Text allowFontScaling={false} style={styles.timelineStepDescription}>
                   {step.description}
                 </Text>
-              </View>
-              <View style={styles.timelineStatus}>
-                <Text
-                  allowFontScaling={false}
-                  style={[styles.timelineStatusText, isActive && styles.timelineStatusActive]}
-                >
-                  {step.statusLabel ?? 'Pending'}
-                </Text>
+                {step.statusLabel ? (
+                  <Text allowFontScaling={false} style={styles.timelineStepLabel}>
+                    {step.statusLabel}
+                  </Text>
+                ) : null}
               </View>
             </Animated.View>
           );
         })}
       </View>
 
-      <View style={styles.orderCard}>
-        <View style={styles.orderCardHeader}>
+      <View style={[styles.courierCard, styles.sectionSpacing]}>
+        <View style={styles.courierBadge}>
+          <Bike size={22} color={accentColor} />
+        </View>
+        <View style={styles.courierInfo}>
+          <Text allowFontScaling={false} style={styles.courierLabel}>
+            Courier
+          </Text>
+          <Text allowFontScaling={false} style={styles.courierName} numberOfLines={1}>
+            {order?.delivery?.courier?.name ?? 'Assigned courier'}
+          </Text>
+          <Text allowFontScaling={false} style={styles.courierStatus} numberOfLines={1}>
+            {activeStep?.statusLabel ?? 'In progress'}
+          </Text>
+        </View>
+        <TouchableOpacity onPress={handleCallCourier} activeOpacity={0.9} style={styles.courierCallButton}>
+          <Phone size={18} color="white" />
+          <Text allowFontScaling={false} style={styles.courierCallLabel}>
+            Call
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={[styles.destinationCard, styles.sectionSpacing]}>
+        <View style={styles.destinationHeader}>
+          <MapPin size={18} color={accentColor} />
+          <Text allowFontScaling={false} style={styles.destinationTitle}>
+            Delivering to
+          </Text>
+        </View>
+        <Text allowFontScaling={false} style={styles.destinationAddress}>
+          {trimmedAddress}
+        </Text>
+      </View>
+
+      <View style={[styles.orderCard, styles.sectionSpacing]}>
+        <View style={styles.orderHeader}>
           <View>
-            <Text allowFontScaling={false} style={styles.orderCardTitle}>
-              My Order
+            <Text allowFontScaling={false} style={styles.orderTitle}>
+              Order summary
             </Text>
-            <Text allowFontScaling={false} style={styles.orderCardSubtitle}>
-              {orderIdLabel}
+            <Text allowFontScaling={false} style={styles.orderSubtitle}>
+              {restaurantName}
             </Text>
           </View>
           {orderTotal ? (
@@ -556,51 +618,40 @@ const OrderTrackingScreen: React.FC = () => {
             </Text>
           ) : null}
         </View>
-        <View style={styles.orderItems}>
-          {displayedItems.map((item, index) => (
-            <View key={`${item.menuItemId}-${index}`} style={styles.orderItemRow}>
-              <Text allowFontScaling={false} style={styles.orderItemText}>
-                {item.quantity} × {item.name}
-              </Text>
-              <Text allowFontScaling={false} style={styles.orderItemPrice}>
-                {formatServerMoney(item.lineTotal)}
-              </Text>
-            </View>
-          ))}
-          {remainingItems > 0 ? (
-            <Text allowFontScaling={false} style={styles.orderMore}>
-              +{remainingItems} more item{remainingItems === 1 ? '' : 's'}
-            </Text>
-          ) : null}
-        </View>
-        <TouchableOpacity
-          activeOpacity={0.9}
-          onPress={handleSeeDetails}
-          disabled={!order}
-          style={[styles.seeDetailsButton, !order && styles.seeDetailsButtonDisabled]}
-        >
-          <Text allowFontScaling={false} style={[styles.seeDetailsText, !order && styles.seeDetailsTextDisabled]}>
-            See details
-          </Text>
-        </TouchableOpacity>
-      </View>
 
-      <View style={styles.courierCard}>
-        <View style={styles.courierInfo}>
-          <Text allowFontScaling={false} style={styles.courierLabel}>
-            Courier
+        {displayedItems.length > 0 ? (
+          <View style={styles.orderItems}>
+            {displayedItems.map((item, index) => (
+              <View
+                key={`${item.menuItem?.id ?? item.name ?? index}-${index}`}
+                style={[
+                  styles.orderItemRow,
+                  index === displayedItems.length - 1 && styles.orderItemRowLast,
+                ]}
+              >
+                <Text allowFontScaling={false} style={styles.orderItemQuantity}>
+                  {item.quantity ?? 1}x
+                </Text>
+                <Text allowFontScaling={false} style={styles.orderItemName} numberOfLines={1}>
+                  {item.menuItem?.name ?? item.name ?? 'Menu item'}
+                </Text>
+              </View>
+            ))}
+            {remainingItems > 0 ? (
+              <Text allowFontScaling={false} style={styles.orderMoreLabel}>
+                +{remainingItems} more item{remainingItems > 1 ? 's' : ''}
+              </Text>
+            ) : null}
+          </View>
+        ) : (
+          <Text allowFontScaling={false} style={styles.emptyItemsText}>
+            Your order details will appear here once confirmed.
           </Text>
-          <Text allowFontScaling={false} style={styles.courierName}>
-            Foodify partner
-          </Text>
-          <Text allowFontScaling={false} style={styles.courierHint}>
-            Call the driver if you need to share instructions.
-          </Text>
-        </View>
-        <TouchableOpacity activeOpacity={0.9} onPress={handleCallCourier} style={styles.courierCallButton}>
-          <Phone color="white" size={18} />
-          <Text allowFontScaling={false} style={styles.courierCallText}>
-            Call driver
+        )}
+
+        <TouchableOpacity onPress={handleSeeDetails} activeOpacity={0.9} style={styles.orderDetailsButton}>
+          <Text allowFontScaling={false} style={styles.orderDetailsLabel}>
+            See details
           </Text>
         </TouchableOpacity>
       </View>
@@ -608,95 +659,113 @@ const OrderTrackingScreen: React.FC = () => {
   );
 
   return (
-    <MainLayout
-      showHeader
-      showFooter={false}
-      customHeader={header}
-      collapsedHeader={collapsedHeader}
-      mainContent={mainContent}
-      headerMaxHeight={360}
-      headerMinHeight={insets.top + 120}
-    />
+    <View style={styles.screen}>
+      <MainLayout
+        showFooter={false}
+        customHeader={header}
+        collapsedHeader={collapsedHeader}
+        mainContent={mainContent}
+        headerMaxHeight={360}
+        headerMinHeight={120}
+        enableHeaderCollapse
+        enforceResponsiveHeaderSize={false}
+      />
+    </View>
   );
 };
 
+export default OrderTrackingScreen;
+
 const styles = StyleSheet.create({
-  headerGradient: {
+  screen: {
     flex: 1,
-    width: '100%',
-    height: '100%',
-    paddingHorizontal: 24,
-    paddingBottom: 32,
+    backgroundColor: softBackground,
   },
-  headerTopRow: {
+  heroContainer: {
+    flex: 1,
+    borderBottomLeftRadius: 28,
+    borderBottomRightRadius: 28,
+    overflow: 'hidden',
+  },
+  heroContent: {
+    flex: 1,
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingBottom: 24,
+  },
+  heroTopRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  heroIconButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 16,
+    backgroundColor: 'rgba(255,255,255,0.18)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  heroTitleBlock: {
+    flex: 1,
+    marginHorizontal: 16,
+  },
+  heroEyebrow: {
+    fontSize: 12,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    color: 'rgba(255,255,255,0.7)',
+    marginBottom: 4,
+    fontWeight: '600',
+  },
+  heroTitle: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: 'white',
+  },
+  heroInfoCard: {
+    backgroundColor: 'rgba(255,255,255,0.94)',
+    borderRadius: 22,
+    padding: 18,
+  },
+  heroInfoRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
   },
-  headerIconButton: {
-    height: 44,
-    width: 44,
-    borderRadius: 22,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: 'rgba(255,255,255,0.18)',
-  },
-  headerLocation: {
-    flex: 1,
-    marginHorizontal: 16,
-  },
-  headerLocationLabel: {
-    fontSize: 12,
-    fontWeight: '600',
-    letterSpacing: 1.4,
-    color: 'rgba(255,255,255,0.72)',
-    textTransform: 'uppercase',
-  },
-  headerLocationValue: {
-    marginTop: 6,
-    fontSize: 18,
-    fontWeight: '700',
-    color: 'white',
-  },
-  headerCallButton: {
-    height: 44,
-    width: 44,
-    borderRadius: 16,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: 'rgba(255,255,255,0.9)',
-  },
-  headerMapCard: {
-    marginTop: 28,
-    borderRadius: 28,
-    backgroundColor: surfaceColor,
-    padding: 16,
-    shadowColor: '#13203B',
-    shadowOpacity: 0.12,
-    shadowRadius: 24,
-    shadowOffset: { width: 0, height: 12 },
-    elevation: 8,
-  },
-  headerEtaChip: {
+  heroEtaPill: {
     flexDirection: 'row',
     alignItems: 'center',
-    alignSelf: 'flex-start',
     backgroundColor: accentMuted,
-    borderRadius: 9999,
+    borderRadius: 999,
     paddingHorizontal: 12,
     paddingVertical: 6,
   },
-  headerEtaText: {
+  heroEtaText: {
     marginLeft: 6,
     fontSize: 13,
     fontWeight: '600',
     color: accentColor,
   },
-  mapWrapper: {
-    marginTop: 12,
-    borderRadius: 20,
-    overflow: 'hidden',
-    height: 180,
+  heroLocationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    backgroundColor: 'rgba(216,58,46,0.1)',
+    borderRadius: 999,
+  },
+  heroLocationText: {
+    marginLeft: 6,
+    fontSize: 13,
+    fontWeight: '600',
+    color: heroText,
+  },
+  heroDescription: {
+    marginTop: 16,
+    fontSize: 14,
+    lineHeight: 20,
+    color: heroText,
+    fontWeight: '500',
   },
   mapDriverMarkerContainer: {
     alignItems: 'center',
@@ -707,7 +776,7 @@ const styles = StyleSheet.create({
     width: 56,
     height: 56,
     borderRadius: 28,
-    backgroundColor: 'rgba(216,58,46,0.2)',
+    backgroundColor: 'rgba(216,58,46,0.25)',
   },
   mapDriverMarker: {
     width: 40,
@@ -727,7 +796,7 @@ const styles = StyleSheet.create({
     height: 18,
     borderRadius: 9,
     borderWidth: 3,
-    borderColor: surfaceColor,
+    borderColor: softSurface,
     backgroundColor: accentColor,
     alignItems: 'center',
     justifyContent: 'center',
@@ -736,19 +805,305 @@ const styles = StyleSheet.create({
     width: 6,
     height: 6,
     borderRadius: 3,
-    backgroundColor: surfaceColor,
+    backgroundColor: softSurface,
   },
-  headerDestinationRow: {
-    marginTop: 16,
+  sheetContainer: {
+    flex: 1,
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 40,
+  },
+  sectionSpacing: {
+    marginTop: 18,
+  },
+  sheetHandle: {
+    alignSelf: 'center',
+    width: 44,
+    height: 4,
+    borderRadius: 999,
+    backgroundColor: '#D1D5DB',
+    marginBottom: 4,
+  },
+  statusCard: {
+    backgroundColor: softSurface,
+    borderRadius: 22,
+    padding: 20,
+    shadowColor: '#0F172A',
+    shadowOpacity: 0.05,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 4,
+  },
+  statusHeaderRow: {
     flexDirection: 'row',
+    justifyContent: 'space-between',
     alignItems: 'flex-start',
   },
-  headerDestinationText: {
-    marginLeft: 8,
-    flex: 1,
+  statusEyebrow: {
+    fontSize: 12,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    color: accentColor,
+    fontWeight: '600',
+  },
+  statusTitle: {
+    marginTop: 6,
+    fontSize: 20,
+    fontWeight: '700',
+    color: heroText,
+  },
+  statusEtaChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: accentMuted,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+  },
+  statusEtaText: {
+    marginLeft: 6,
     fontSize: 13,
     fontWeight: '600',
-    color: heroDark,
+    color: accentColor,
+  },
+  statusDescription: {
+    marginTop: 14,
+    fontSize: 14,
+    lineHeight: 20,
+    color: secondaryText,
+  },
+  timelineCard: {
+    backgroundColor: softSurface,
+    borderRadius: 22,
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+    shadowColor: '#0F172A',
+    shadowOpacity: 0.04,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 3,
+  },
+  timelineTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: heroText,
+    marginBottom: 12,
+  },
+  timelineRow: {
+    flexDirection: 'row',
+    marginBottom: 16,
+  },
+  timelineRowLast: {
+    marginBottom: 0,
+  },
+  timelineIndicator: {
+    alignItems: 'center',
+    marginRight: 16,
+  },
+  timelineDot: {
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    backgroundColor: '#E5E7EB',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  timelineDotActive: {
+    backgroundColor: 'rgba(216,58,46,0.15)',
+    borderWidth: 2,
+    borderColor: accentColor,
+  },
+  timelineDotCompleted: {
+    backgroundColor: accentColor,
+  },
+  timelineConnector: {
+    flex: 1,
+    width: 2,
+    backgroundColor: '#E5E7EB',
+    marginTop: 4,
+  },
+  timelineConnectorActive: {
+    backgroundColor: accentColor,
+  },
+  timelineContent: {
+    flex: 1,
+  },
+  timelineStepTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: heroText,
+  },
+  timelineStepDescription: {
+    marginTop: 4,
+    fontSize: 13,
+    lineHeight: 18,
+    color: secondaryText,
+  },
+  timelineStepLabel: {
+    marginTop: 6,
+    fontSize: 12,
+    fontWeight: '600',
+    color: accentColor,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  courierCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: softSurface,
+    borderRadius: 20,
+    paddingHorizontal: 18,
+    paddingVertical: 16,
+    shadowColor: '#0F172A',
+    shadowOpacity: 0.04,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 3,
+  },
+  courierBadge: {
+    width: 48,
+    height: 48,
+    borderRadius: 16,
+    backgroundColor: accentMuted,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  courierInfo: {
+    flex: 1,
+    marginHorizontal: 16,
+  },
+  courierLabel: {
+    fontSize: 12,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    color: secondaryText,
+    fontWeight: '600',
+  },
+  courierName: {
+    marginTop: 4,
+    fontSize: 16,
+    fontWeight: '700',
+    color: heroText,
+  },
+  courierStatus: {
+    marginTop: 4,
+    fontSize: 13,
+    color: secondaryText,
+  },
+  courierCallButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: accentColor,
+    borderRadius: 999,
+    paddingHorizontal: 18,
+    paddingVertical: 10,
+  },
+  courierCallLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: 'white',
+    marginLeft: 8,
+  },
+  destinationCard: {
+    backgroundColor: softSurface,
+    borderRadius: 20,
+    padding: 18,
+    shadowColor: '#0F172A',
+    shadowOpacity: 0.04,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 2,
+  },
+  destinationHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  destinationTitle: {
+    marginLeft: 8,
+    fontSize: 14,
+    fontWeight: '700',
+    color: heroText,
+  },
+  destinationAddress: {
+    marginTop: 10,
+    fontSize: 14,
+    lineHeight: 20,
+    color: secondaryText,
+  },
+  orderCard: {
+    backgroundColor: softSurface,
+    borderRadius: 22,
+    padding: 20,
+    shadowColor: '#0F172A',
+    shadowOpacity: 0.05,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 4,
+  },
+  orderHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  orderTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: heroText,
+  },
+  orderSubtitle: {
+    marginTop: 4,
+    fontSize: 13,
+    color: secondaryText,
+  },
+  orderTotal: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: accentColor,
+  },
+  orderItems: {
+    marginTop: 16,
+  },
+  orderItemRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  orderItemRowLast: {
+    marginBottom: 0,
+  },
+  orderItemQuantity: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: accentColor,
+    marginRight: 10,
+  },
+  orderItemName: {
+    flex: 1,
+    fontSize: 14,
+    color: heroText,
+    fontWeight: '500',
+  },
+  orderMoreLabel: {
+    marginTop: 4,
+    fontSize: 13,
+    color: secondaryText,
+  },
+  emptyItemsText: {
+    marginTop: 16,
+    fontSize: 14,
+    color: secondaryText,
+  },
+  orderDetailsButton: {
+    marginTop: 20,
+    backgroundColor: heroText,
+    borderRadius: 16,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  orderDetailsLabel: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: 'white',
   },
   collapsedHeader: {
     flex: 1,
@@ -767,7 +1122,7 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: 'rgba(255,255,255,0.15)',
+    backgroundColor: 'rgba(255,255,255,0.18)',
   },
   collapsedTexts: {
     flex: 1,
@@ -797,238 +1152,6 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: surfaceColor,
-  },
-  contentContainer: {
-    paddingHorizontal: 24,
-    paddingBottom: 48,
-    paddingTop: 8,
-    backgroundColor: softBackground,
-    flex: 1,
-  },
-  timelineCard: {
-    backgroundColor: surfaceColor,
-    borderRadius: 28,
-    padding: 24,
-    shadowColor: '#13203B',
-    shadowOpacity: 0.08,
-    shadowRadius: 24,
-    shadowOffset: { width: 0, height: 10 },
-    elevation: 6,
-  },
-  timelineHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: 12,
-  },
-  timelineTitle: {
-    fontSize: 20,
-    fontWeight: '700',
-    color: heroDark,
-  },
-  timelineSubtitle: {
-    marginTop: 4,
-    fontSize: 14,
-    color: mutedText,
-  },
-  timelineStepChip: {
-    backgroundColor: accentMuted,
-    borderRadius: 9999,
-    paddingHorizontal: 14,
-    paddingVertical: 6,
-  },
-  timelineStepText: {
-    fontSize: 12,
-    fontWeight: '600',
-    color: accentColor,
-  },
-  timelineRow: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    marginTop: 18,
-  },
-  timelineIndicator: {
-    alignItems: 'center',
-    width: 32,
-  },
-  timelineDot: {
-    width: 26,
-    height: 26,
-    borderRadius: 13,
-    borderWidth: 2,
-    borderColor: '#E5E7EB',
-    backgroundColor: surfaceColor,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  timelineDotActive: {
-    borderColor: accentColor,
-  },
-  timelineDotCompleted: {
-    backgroundColor: accentColor,
-    borderColor: accentColor,
-  },
-  timelineConnector: {
-    width: 2,
-    flex: 1,
-    marginTop: 6,
-    backgroundColor: '#E5E7EB',
-  },
-  timelineConnectorActive: {
-    backgroundColor: `${accentColor}55`,
-  },
-  timelineContent: {
-    flex: 1,
-    marginLeft: 8,
-    marginRight: 12,
-  },
-  timelineRowTitle: {
-    fontSize: 15,
-    fontWeight: '700',
-    color: headingText,
-  },
-  timelineDescription: {
-    marginTop: 6,
-    fontSize: 13,
-    lineHeight: 18,
-    color: mutedText,
-  },
-  timelineStatus: {
-    alignItems: 'flex-end',
-    minWidth: 80,
-  },
-  timelineStatusText: {
-    fontSize: 12,
-    fontWeight: '600',
-    color: mutedText,
-    textTransform: 'uppercase',
-    letterSpacing: 1,
-  },
-  timelineStatusActive: {
-    color: accentColor,
-  },
-  orderCard: {
-    marginTop: 28,
-    backgroundColor: surfaceColor,
-    borderRadius: 28,
-    padding: 24,
-    shadowColor: '#13203B',
-    shadowOpacity: 0.08,
-    shadowRadius: 24,
-    shadowOffset: { width: 0, height: 10 },
-    elevation: 6,
-  },
-  orderCardHeader: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    justifyContent: 'space-between',
-  },
-  orderCardTitle: {
-    fontSize: 18,
-    fontWeight: '700',
-    color: heroDark,
-  },
-  orderCardSubtitle: {
-    marginTop: 6,
-    fontSize: 13,
-    color: mutedText,
-  },
-  orderTotal: {
-    fontSize: 16,
-    fontWeight: '700',
-    color: accentColor,
-  },
-  orderItems: {
-    marginTop: 16,
-  },
-  orderItemRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginTop: 10,
-  },
-  orderItemText: {
-    fontSize: 14,
-    color: headingText,
-    flex: 1,
-    marginRight: 16,
-  },
-  orderItemPrice: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: headingText,
-  },
-  orderMore: {
-    marginTop: 14,
-    fontSize: 13,
-    fontWeight: '600',
-    color: accentColor,
-  },
-  seeDetailsButton: {
-    marginTop: 20,
-    borderRadius: 16,
-    borderWidth: 1,
-    borderColor: accentColor,
-    paddingVertical: 12,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: 'white',
-  },
-  seeDetailsButtonDisabled: {
-    borderColor: '#E5E7EB',
-    backgroundColor: '#F9FAFB',
-  },
-  seeDetailsText: {
-    fontSize: 14,
-    fontWeight: '700',
-    color: accentColor,
-  },
-  seeDetailsTextDisabled: {
-    color: '#9CA3AF',
-  },
-  courierCard: {
-    marginTop: 24,
-    backgroundColor: heroDark,
-    borderRadius: 28,
-    padding: 24,
-  },
-  courierInfo: {
-    marginBottom: 18,
-  },
-  courierLabel: {
-    fontSize: 12,
-    letterSpacing: 1.4,
-    textTransform: 'uppercase',
-    color: 'rgba(255,255,255,0.7)',
-    fontWeight: '600',
-  },
-  courierName: {
-    marginTop: 10,
-    fontSize: 20,
-    fontWeight: '700',
-    color: 'white',
-  },
-  courierHint: {
-    marginTop: 8,
-    fontSize: 13,
-    lineHeight: 18,
-    color: 'rgba(255,255,255,0.7)',
-  },
-  courierCallButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 18,
-    paddingVertical: 14,
-    backgroundColor: accentColor,
-  },
-  courierCallText: {
-    marginLeft: 8,
-    fontSize: 15,
-    fontWeight: '700',
-    color: 'white',
+    backgroundColor: softSurface,
   },
 });
-
-export default OrderTrackingScreen;

--- a/src/screens/OrderTracking.tsx
+++ b/src/screens/OrderTracking.tsx
@@ -28,6 +28,7 @@ import {
 } from '@react-navigation/native';
 
 import type { CreateOrderResponse, MonetaryAmount } from '~/interfaces/Order';
+import { vs } from 'react-native-size-matters';
 const HEADER_MAX_HEIGHT = 320;
 const HEADER_MIN_HEIGHT = 72;
 const COLLAPSE_THRESHOLD = 80;
@@ -173,7 +174,7 @@ const buildWorkflowSteps = (order: CreateOrderResponse | null | undefined): Work
       statusText:
         index === 0 ? 'Completed' : index === 1 ? 'Preparing' : 'Pending',
       etaLabel: index === 0 ? '4 m 34s' : index === 1 ? '24s' : '0s',
-      state,
+      state: index === 0 ? 'completed': index === 1  ? 'active': 'pending',
     } satisfies WorkflowStep;
   });
 
@@ -198,7 +199,7 @@ const buildWorkflowSteps = (order: CreateOrderResponse | null | undefined): Work
         state === 'completed' ? 'Completed' : state === 'active' ? 'Preparing' : 'Pending',
       etaLabel:
         index === 0 ? '4 m 34s' : index === 1 ? '24s' : index === 2 ? '0s' : '1m 20s',
-      state,
+      state: index === 0 ? 'completed': index === 1  ? 'active': 'pending',
     } satisfies WorkflowStep;
   });
 };
@@ -349,23 +350,6 @@ const OrderTrackingScreen: React.FC = () => {
           <ArrowLeft size={20} color="white" />
         </TouchableOpacity>
       </View>
-
-      {!collapsed ? (
-        <Animated.View style={[styles.bannerContainer, { opacity: bannerOpacity }]}>
-          <View style={styles.bannerRibbon}>
-            <Text style={styles.bannerLabel}>Delivering to</Text>
-            <View style={styles.bannerLocationRow}>
-              <MapPin size={16} color="white" />
-              <View style={styles.bannerTexts}>
-                <Text style={styles.bannerLocation}>{deliveryArea}</Text>
-                <Text style={styles.bannerAddress} numberOfLines={1}>
-                  {deliveryAddress}
-                </Text>
-              </View>
-            </View>
-          </View>
-        </Animated.View>
-      ) : null}
     </View>
   );
 
@@ -465,24 +449,6 @@ const OrderTrackingScreen: React.FC = () => {
               </Text>
             </View>
             <View style={styles.stepMeta}>
-              {(isCompleted || isActive) && (
-                <View
-                  style={[
-                    styles.stepStatusBadge,
-                    isCompleted && styles.stepStatusBadgeCompleted,
-                    isActive && styles.stepStatusBadgeActive,
-                  ]}
-                >
-                  <Text
-                    style={[
-                      styles.stepStatusLabel,
-                      (isCompleted || isActive) && styles.stepStatusLabelContrast,
-                    ]}
-                  >
-                    {step.statusText}
-                  </Text>
-                </View>
-              )}
               <View
                 style={[
                   styles.stepEtaBadge,
@@ -522,7 +488,7 @@ const OrderTrackingScreen: React.FC = () => {
 
       <Animated.ScrollView
         style={styles.scroll}
-        contentContainerStyle={[styles.scrollContent, { paddingBottom: 320 }]}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: vs(180) }]}
         showsVerticalScrollIndicator={false}
         onScroll={handleScroll}
         scrollEventThrottle={16}
@@ -536,7 +502,7 @@ const OrderTrackingScreen: React.FC = () => {
           <View style={styles.summaryHeader}>
             <View style={styles.summaryHeaderLeft}>
               <Image
-                source={{ uri: restaurantAvatarUri }}
+                source={{ uri: '../../../assets/baguette.png' }}
                 style={styles.summaryRestaurantImage}
               />
               <Text style={styles.summaryTitle}>My Order</Text>

--- a/src/screens/OrderTracking.tsx
+++ b/src/screens/OrderTracking.tsx
@@ -5,6 +5,7 @@ import {
   TouchableOpacity,
   StyleSheet,
   Animated,
+  Image,
 } from 'react-native';
 import MapView, { Marker, type Region } from 'react-native-maps';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -225,6 +226,11 @@ const OrderTrackingScreen: React.FC = () => {
     ? courierDeliveriesValue
     : 120;
   const courierName = order?.delivery?.courier?.name ?? 'Assigned courier';
+  const courierAvatarUri =
+    (order as any)?.delivery?.courier?.avatarUrl ?? 'https://i.pravatar.cc/96?img=12';
+  const restaurantAvatarUri =
+    (order as any)?.restaurant?.imageUrl ??
+    'https://images.unsplash.com/photo-1606755962773-0e7d61a9b1fc?auto=format&fit=crop&w=200&q=80';
 
   const driverCoordinate = useMemo<LatLng>(() => {
     const courierLocation = (order as any)?.delivery?.courier?.location;
@@ -481,7 +487,13 @@ const OrderTrackingScreen: React.FC = () => {
       <View style={[styles.bottomSheet, { paddingBottom: insets.bottom + 12 }]}>
         <View style={styles.summaryCard}>
           <View style={styles.summaryHeader}>
-            <Text style={styles.summaryTitle}>My Order</Text>
+            <View style={styles.summaryHeaderLeft}>
+              <Image
+                source={{ uri: restaurantAvatarUri }}
+                style={styles.summaryRestaurantImage}
+              />
+              <Text style={styles.summaryTitle}>My Order</Text>
+            </View>
             <View style={styles.summaryBadge}>
               <Text style={styles.summaryBadgeText}>
                 {order?.restaurant?.name ?? 'Your restaurant'}
@@ -519,14 +531,17 @@ const OrderTrackingScreen: React.FC = () => {
         </View>
 
         <View style={styles.courierStickyCard}>
-          <View>
-            <Text style={styles.courierStickyLabel}>Delivered by</Text>
-            <Text style={styles.courierStickyName}>{courierName}</Text>
-            <View style={styles.courierStickyRating}>
-              <Star size={14} color={accentColor} fill={accentColor} />
-              <Text style={styles.courierStickyRatingText}>
-                {courierRating} / 5 ({courierDeliveries})
-              </Text>
+          <View style={styles.courierInfo}>
+            <Image source={{ uri: courierAvatarUri }} style={styles.courierAvatar} />
+            <View>
+              <Text style={styles.courierStickyLabel}>Delivered by</Text>
+              <Text style={styles.courierStickyName}>{courierName}</Text>
+              <View style={styles.courierStickyRating}>
+                <Star size={14} color={accentColor} fill={accentColor} />
+                <Text style={styles.courierStickyRatingText}>
+                  {courierRating} / 5 ({courierDeliveries})
+                </Text>
+              </View>
             </View>
           </View>
           <View style={styles.courierStickyActions}>
@@ -799,6 +814,17 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     marginBottom: 10,
   },
+  summaryHeaderLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  summaryRestaurantImage: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    marginRight: 10,
+    backgroundColor: '#F1F5F9',
+  },
   summaryTitle: {
     fontSize: 14,
     fontWeight: '700',
@@ -881,6 +907,18 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
     shadowOffset: { width: 0, height: 2 },
     elevation: 1,
+  },
+  courierInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+  courierAvatar: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    marginRight: 12,
+    backgroundColor: '#F1F5F9',
   },
   courierStickyLabel: {
     color: textSecondary,

--- a/src/screens/OrderTracking.tsx
+++ b/src/screens/OrderTracking.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import type { ViewStyle } from 'react-native';
-import { Animated, Easing, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Animated, Easing, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import MapView, { Marker, Polyline, type MapStyleElement, type Region } from 'react-native-maps';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import {
   NavigationProp,
@@ -14,6 +14,7 @@ import {
 import { ArrowLeft, Bike, CheckCircle2, Clock, MapPin, Phone } from 'lucide-react-native';
 
 import type { CreateOrderResponse, MonetaryAmount } from '~/interfaces/Order';
+import MainLayout from '~/layouts/MainLayout';
 
 const accentColor = '#D83A2E';
 const heroDark = '#1A253A';
@@ -151,6 +152,7 @@ const OrderTrackingScreen: React.FC = () => {
   const navigation = useNavigation<NavigationProp<ParamListBase>>();
   const route = useRoute<OrderTrackingRoute>();
   const order = route.params?.order ?? null;
+  const insets = useSafeAreaInsets();
 
   const { steps, activeIndex } = useMemo(() => {
     if (order?.workflow?.length) {
@@ -343,299 +345,395 @@ const OrderTrackingScreen: React.FC = () => {
   const displayedItems = useMemo(() => (order?.items ?? []).slice(0, 3), [order?.items]);
   const remainingItems = Math.max(0, (order?.items?.length ?? 0) - displayedItems.length);
 
-  return (
-    <SafeAreaView className="flex-1" style={{ backgroundColor: softBackground }}>
-      <ScrollView className="flex-1" contentContainerStyle={{ paddingBottom: 40 }}>
-        <LinearGradient
-          colors={[accentColor, '#F0644B']}
-          start={{ x: 0, y: 0 }}
-          end={{ x: 1, y: 1 }}
-          style={styles.hero}
-        >
-          <View className="px-6 pt-2 pb-12">
-            <View className="flex-row items-center justify-between">
-              <TouchableOpacity
-                onPress={() => navigation.goBack()}
-                activeOpacity={0.85}
-                className="h-11 w-11 items-center justify-center rounded-full bg-white/20"
-              >
-                <ArrowLeft color="white" size={22} />
-              </TouchableOpacity>
-              <View className="rounded-full bg-white/20 px-4 py-2">
-                <Text allowFontScaling={false} className="text-xs font-semibold uppercase tracking-[2px] text-white/90">
-                  {orderIdLabel}
-                </Text>
-              </View>
-            </View>
+  const handleGoBack = () => {
+    navigation.goBack();
+  };
 
-            <View className="mt-8">
-              <Text allowFontScaling={false} className="text-xs font-semibold uppercase tracking-[4px] text-white/70">
-                Now
-              </Text>
-              <Text allowFontScaling={false} className="mt-3 text-3xl font-bold text-white">
-                {activeStep?.title ?? 'Order in progress'}
-              </Text>
-              <Text allowFontScaling={false} className="mt-4 text-sm leading-5 text-white/85">
-                {activeStep?.description ?? `We are looking after your order from ${restaurantName}.`}
-              </Text>
-            </View>
+  const handleCallCourier = () => {};
 
-            <View style={styles.heroSummary}>
-              <View style={styles.heroSummaryItem}>
-                <Clock size={18} color={accentColor} />
-                <View className="ml-3">
-                  <Text allowFontScaling={false} style={styles.heroSummaryLabel}>
-                    Estimated time
-                  </Text>
-                  <Text allowFontScaling={false} style={styles.heroSummaryValue}>
-                    {estimatedWindow}
-                  </Text>
-                </View>
-              </View>
-              <View style={[styles.heroSummaryItem, { marginTop: 16 }]}> 
-                <MapPin size={18} color={accentColor} />
-                <View className="ml-3 flex-1">
-                  <Text allowFontScaling={false} style={styles.heroSummaryLabel}>
-                    {addressLabel}
-                  </Text>
-                  <Text allowFontScaling={false} style={styles.heroSummaryValue} numberOfLines={2}>
-                    {trimmedAddress}
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-        </LinearGradient>
-
-        <View style={styles.contentWrapper}>
-          <View style={styles.contactCard}>
-            <View>
-              <Text allowFontScaling={false} style={styles.contactLabel}>
-                Your courier
-              </Text>
-              <Text allowFontScaling={false} style={styles.contactName}>
-                Foodify partner
-              </Text>
-              <Text allowFontScaling={false} style={styles.contactHint}>
-                Reach out if you need to share delivery instructions.
-              </Text>
-            </View>
-            <TouchableOpacity activeOpacity={0.9} style={styles.contactButton}>
-              <Phone color="white" size={18} />
-              <Text allowFontScaling={false} style={styles.contactButtonText}>
-                Call courier
-              </Text>
-            </TouchableOpacity>
-          </View>
-
-          <View style={[styles.card, styles.mapCard]}>
-            <View style={styles.cardHeader}>
-              <Text allowFontScaling={false} style={styles.cardTitle}>
-                Courier location
-              </Text>
-              <View style={styles.statusChip}>
-                <Text allowFontScaling={false} style={styles.statusChipText}>
-                  {estimatedWindow}
-                </Text>
-              </View>
-            </View>
-            <Text allowFontScaling={false} style={styles.cardSubtitle}>
-              {activeStep?.statusLabel ?? 'On the move to you'}
+  const heroHeader = (
+    <LinearGradient
+      colors={[accentColor, '#F0644B']}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={styles.hero}
+    >
+      <View
+        style={[styles.heroContent, { paddingTop: insets.top + 12 }]}
+      >
+        <View style={styles.heroTopRow}>
+          <TouchableOpacity onPress={handleGoBack} activeOpacity={0.85} style={styles.heroIconButton}>
+            <ArrowLeft color="white" size={22} />
+          </TouchableOpacity>
+          <View style={styles.orderChip}>
+            <Text allowFontScaling={false} style={styles.orderChipText}>
+              {orderIdLabel}
             </Text>
-            <View style={styles.mapWrapper}>
-              <MapView
-                style={styles.map}
-                region={mapRegion}
-                scrollEnabled={false}
-                rotateEnabled={false}
-                pitchEnabled={false}
-                zoomEnabled={false}
-                customMapStyle={mapTheme}
-                showsBuildings={false}
-                showsCompass={false}
-                showsPointsOfInterest={false}
-              >
-                <Polyline
-                  coordinates={routeCoordinates}
-                  strokeColor="rgba(216,58,46,0.9)"
-                  strokeWidth={5}
-                  lineCap="round"
-                  lineJoin="round"
-                />
-                <Marker coordinate={driverCoordinate} anchor={{ x: 0.5, y: 0.5 }}>
-                  <View style={styles.mapDriverMarkerContainer}>
-                    <Animated.View
-                      style={[
-                        styles.mapDriverPulse,
-                        { transform: [{ scale: pulseScale }], opacity: pulseOpacity },
-                      ]}
-                    />
-                    <View style={styles.mapDriverMarker}>
-                      <Bike size={18} color="white" />
-                    </View>
-                  </View>
-                </Marker>
-                <Marker coordinate={destinationCoordinate} anchor={{ x: 0.5, y: 0.95 }}>
-                  <View style={styles.destinationMarker}>
-                    <View style={styles.destinationDot} />
-                  </View>
-                </Marker>
-              </MapView>
+          </View>
+        </View>
+
+        <View style={styles.heroStatus}>
+          <Text allowFontScaling={false} style={styles.heroNowLabel}>
+            Now
+          </Text>
+          <Text allowFontScaling={false} style={styles.heroTitle}>
+            {activeStep?.title ?? 'Order in progress'}
+          </Text>
+          <Text allowFontScaling={false} style={styles.heroDescription}>
+            {activeStep?.description ?? `We are looking after your order from ${restaurantName}.`}
+          </Text>
+        </View>
+
+        <View style={styles.heroSummary}>
+          <View style={styles.heroSummaryItem}>
+            <Clock size={18} color={accentColor} />
+            <View style={styles.heroSummaryText}>
+              <Text allowFontScaling={false} style={styles.heroSummaryLabel}>
+                Estimated time
+              </Text>
+              <Text allowFontScaling={false} style={styles.heroSummaryValue}>
+                {estimatedWindow}
+              </Text>
             </View>
-            <View style={styles.mapFooter}>
-              <MapPin size={16} color={accentColor} />
-              <Text allowFontScaling={false} style={styles.mapFooterText} numberOfLines={1}>
+          </View>
+          <View style={[styles.heroSummaryItem, styles.heroSummarySpacer]}>
+            <MapPin size={18} color={accentColor} />
+            <View style={[styles.heroSummaryText, { flex: 1 }]}>
+              <Text allowFontScaling={false} style={styles.heroSummaryLabel}>
+                {addressLabel}
+              </Text>
+              <Text allowFontScaling={false} style={styles.heroSummaryValue} numberOfLines={2}>
                 {trimmedAddress}
               </Text>
             </View>
           </View>
+        </View>
+      </View>
+    </LinearGradient>
+  );
 
-          <View style={[styles.card, { marginTop: 24 }]}>
-            <View style={styles.cardHeader}>
-              <Text allowFontScaling={false} style={styles.cardTitle}>
-                Live order status
+  const collapsedHeader = (
+    <LinearGradient colors={[accentColor, '#F0644B']} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.collapsedHero}>
+      <View style={[styles.collapsedHeaderContent, { paddingTop: insets.top + 6 }]}>
+        <TouchableOpacity onPress={handleGoBack} activeOpacity={0.85} style={styles.collapsedIconButton}>
+          <ArrowLeft color="white" size={20} />
+        </TouchableOpacity>
+        <View style={styles.collapsedHeaderText}>
+          <Text allowFontScaling={false} style={styles.collapsedOrderId} numberOfLines={1}>
+            {orderIdLabel}
+          </Text>
+          <Text allowFontScaling={false} style={styles.collapsedTitle} numberOfLines={1}>
+            {activeStep?.title ?? 'Order in progress'}
+          </Text>
+          <Text allowFontScaling={false} style={styles.collapsedMeta} numberOfLines={1}>
+            ETA {estimatedWindow} • {activeStep?.statusLabel ?? 'In progress'}
+          </Text>
+        </View>
+        <TouchableOpacity onPress={handleCallCourier} activeOpacity={0.9} style={styles.collapsedCallButton}>
+          <Phone color={accentColor} size={18} />
+        </TouchableOpacity>
+      </View>
+    </LinearGradient>
+  );
+
+  const mainContent = (
+    <View style={styles.screenContent}>
+      <View style={styles.contentWrapper}>
+        <View style={styles.contactCard}>
+          <View style={styles.contactInfo}>
+            <Text allowFontScaling={false} style={styles.contactLabel}>
+              Your courier
+            </Text>
+            <Text allowFontScaling={false} style={styles.contactName}>
+              Foodify partner
+            </Text>
+            <Text allowFontScaling={false} style={styles.contactHint}>
+              Reach out if you need to share delivery instructions.
+            </Text>
+          </View>
+          <TouchableOpacity activeOpacity={0.9} onPress={handleCallCourier} style={styles.contactButton}>
+            <Phone color="white" size={18} />
+            <Text allowFontScaling={false} style={styles.contactButtonText}>
+              Call courier
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        <View style={[styles.card, styles.mapCard]}>
+          <View style={styles.cardHeader}>
+            <Text allowFontScaling={false} style={styles.cardTitle}>
+              Courier location
+            </Text>
+            <View style={styles.statusChip}>
+              <Text allowFontScaling={false} style={styles.statusChipText}>
+                {estimatedWindow}
               </Text>
-              <View style={styles.statusChipMuted}>
-                <Text allowFontScaling={false} style={styles.statusChipMutedText}>
-                  Step {activeIndex + 1} of {steps.length}
-                </Text>
-              </View>
             </View>
-
-            {steps.map((step, index) => {
-              const isActive = index === activeIndex;
-              const isCompleted = index < activeIndex || (steps.length - 1 === index && step.completed);
-              const timelineValue = timelineAnimations[index];
-              const animatedStyle: Animated.WithAnimatedObject<ViewStyle> | undefined = timelineValue
-                ? {
-                    opacity: timelineValue,
-                    transform: [
-                      {
-                        translateY: timelineValue.interpolate({ inputRange: [0, 1], outputRange: [18, 0] }),
-                      },
-                    ],
-                  }
-                : undefined;
-
-              return (
-                <Animated.View key={`${step.key}-${index}`} style={[styles.timelineRow, animatedStyle]}>
-                  <View style={styles.timelineIconWrapper}>
-                    <View
-                      style={[
-                        styles.timelineDot,
-                        {
-                          backgroundColor: isCompleted || isActive ? accentColor : softSurface,
-                          borderColor: isCompleted || isActive ? accentColor : '#D1D5DB',
-                        },
-                      ]}
-                    >
-                      {isCompleted ? <CheckCircle2 size={14} color="white" /> : null}
-                    </View>
-                    {index < steps.length - 1 ? (
-                      <View
-                        style={[
-                          styles.timelineLine,
-                          { backgroundColor: isCompleted ? `${accentColor}55` : '#E5E7EB' },
-                        ]}
-                      />
-                    ) : null}
+          </View>
+          <Text allowFontScaling={false} style={styles.cardSubtitle}>
+            {activeStep?.statusLabel ?? 'On the move to you'}
+          </Text>
+          <View style={styles.mapWrapper}>
+            <MapView
+              style={styles.map}
+              region={mapRegion}
+              scrollEnabled={false}
+              rotateEnabled={false}
+              pitchEnabled={false}
+              zoomEnabled={false}
+              customMapStyle={mapTheme}
+              showsBuildings={false}
+              showsCompass={false}
+              showsPointsOfInterest={false}
+            >
+              <Polyline
+                coordinates={routeCoordinates}
+                strokeColor="rgba(216,58,46,0.9)"
+                strokeWidth={5}
+                lineCap="round"
+                lineJoin="round"
+              />
+              <Marker coordinate={driverCoordinate} anchor={{ x: 0.5, y: 0.5 }}>
+                <View style={styles.mapDriverMarkerContainer}>
+                  <Animated.View
+                    style={[
+                      styles.mapDriverPulse,
+                      { transform: [{ scale: pulseScale }], opacity: pulseOpacity },
+                    ]}
+                  />
+                  <View style={styles.mapDriverMarker}>
+                    <Bike size={18} color="white" />
                   </View>
-                  <View style={styles.timelineContent}>
-                    <Text
-                      allowFontScaling={false}
-                      style={[styles.timelineTitle, { color: isActive ? accentColor : headingText }]}
-                    >
-                      {step.title}
-                    </Text>
-                    <Text allowFontScaling={false} style={styles.timelineDescription}>
-                      {step.description}
-                    </Text>
-                    {step.statusLabel ? (
-                      <View style={styles.timelineChip}>
-                        <Text allowFontScaling={false} style={styles.timelineChipText}>
-                          {step.statusLabel}
-                        </Text>
-                      </View>
-                    ) : null}
-                  </View>
-                </Animated.View>
-              );
-            })}
+                </View>
+              </Marker>
+              <Marker coordinate={destinationCoordinate} anchor={{ x: 0.5, y: 0.95 }}>
+                <View style={styles.destinationMarker}>
+                  <View style={styles.destinationDot} />
+                </View>
+              </Marker>
+            </MapView>
+          </View>
+          <View style={styles.mapFooter}>
+            <MapPin size={16} color={accentColor} />
+            <Text allowFontScaling={false} style={styles.mapFooterText} numberOfLines={1}>
+              {trimmedAddress}
+            </Text>
+          </View>
+        </View>
+
+        <View style={[styles.card, { marginTop: 24 }]}>
+          <View style={styles.cardHeader}>
+            <Text allowFontScaling={false} style={styles.cardTitle}>
+              Live order status
+            </Text>
+            <View style={styles.statusChipMuted}>
+              <Text allowFontScaling={false} style={styles.statusChipMutedText}>
+                Step {activeIndex + 1} of {steps.length}
+              </Text>
+            </View>
           </View>
 
-          <View style={[styles.card, { marginTop: 24 }]}> 
-            <View style={styles.cardHeader}>
-              <Text allowFontScaling={false} style={styles.cardTitle}>
-                Order summary
+          {steps.map((step, index) => {
+            const isActive = index === activeIndex;
+            const isCompleted = index < activeIndex || (steps.length - 1 === index && step.completed);
+            const timelineValue = timelineAnimations[index];
+            const animatedStyle: Animated.WithAnimatedObject<ViewStyle> | undefined = timelineValue
+              ? {
+                  opacity: timelineValue,
+                  transform: [
+                    {
+                      translateY: timelineValue.interpolate({ inputRange: [0, 1], outputRange: [18, 0] }),
+                    },
+                  ],
+                }
+              : undefined;
+
+            return (
+              <Animated.View key={`${step.key}-${index}`} style={[styles.timelineRow, animatedStyle]}>
+                <View style={styles.timelineIconWrapper}>
+                  <View
+                    style={[
+                      styles.timelineDot,
+                      {
+                        backgroundColor: isCompleted || isActive ? accentColor : softSurface,
+                        borderColor: isCompleted || isActive ? accentColor : '#D1D5DB',
+                      },
+                    ]}
+                  >
+                    {isCompleted ? <CheckCircle2 size={14} color="white" /> : null}
+                  </View>
+                  {index < steps.length - 1 ? (
+                    <View
+                      style={[
+                        styles.timelineLine,
+                        { backgroundColor: isCompleted ? `${accentColor}55` : '#E5E7EB' },
+                      ]}
+                    />
+                  ) : null}
+                </View>
+                <View style={styles.timelineContent}>
+                  <Text
+                    allowFontScaling={false}
+                    style={[styles.timelineTitle, { color: isActive ? accentColor : headingText }]}
+                  >
+                    {step.title}
+                  </Text>
+                  <Text allowFontScaling={false} style={styles.timelineDescription}>
+                    {step.description}
+                  </Text>
+                  {step.statusLabel ? (
+                    <View style={styles.timelineChip}>
+                      <Text allowFontScaling={false} style={styles.timelineChipText}>
+                        {step.statusLabel}
+                      </Text>
+                    </View>
+                  ) : null}
+                </View>
+              </Animated.View>
+            );
+          })}
+        </View>
+
+        <View style={[styles.card, { marginTop: 24 }]}>
+          <View style={styles.cardHeader}>
+            <Text allowFontScaling={false} style={styles.cardTitle}>
+              Order summary
+            </Text>
+            {orderTotal ? (
+              <Text allowFontScaling={false} style={styles.summaryTotal}>
+                {orderTotal}
               </Text>
-              {orderTotal ? (
-                <Text allowFontScaling={false} style={styles.summaryTotal}>
-                  {orderTotal}
+            ) : null}
+          </View>
+          <Text allowFontScaling={false} style={styles.cardSubtitle}>
+            Payment method: {paymentMethod}
+          </Text>
+
+          {displayedItems.length ? (
+            <View style={styles.summaryItemsWrapper}>
+              {displayedItems.map((item) => (
+                <View key={`${item.menuItemId}-${item.name}`} style={styles.summaryItemRow}>
+                  <View style={{ flex: 1, paddingRight: 12 }}>
+                    <Text allowFontScaling={false} style={styles.summaryItemTitle}>
+                      {item.quantity} × {item.name}
+                    </Text>
+                    {item.extras?.length ? (
+                      <Text allowFontScaling={false} style={styles.summaryItemExtras}>
+                        Extras: {item.extras.map((extra) => extra.name).join(', ')}
+                      </Text>
+                    ) : null}
+                  </View>
+                  <Text allowFontScaling={false} style={styles.summaryItemPrice}>
+                    {formatServerMoney(item.lineTotal)}
+                  </Text>
+                </View>
+              ))}
+              {remainingItems > 0 ? (
+                <Text allowFontScaling={false} style={styles.summaryMore}>
+                  + {remainingItems} more {remainingItems === 1 ? 'item' : 'items'}
                 </Text>
               ) : null}
             </View>
-            <Text allowFontScaling={false} style={styles.cardSubtitle}>
-              Payment method: {paymentMethod}
-            </Text>
+          ) : null}
 
-            {displayedItems.length ? (
-              <View style={styles.summaryItemsWrapper}>
-                {displayedItems.map((item) => (
-                  <View key={`${item.menuItemId}-${item.name}`} style={styles.summaryItemRow}>
-                    <View style={{ flex: 1, paddingRight: 12 }}>
-                      <Text allowFontScaling={false} style={styles.summaryItemTitle}>
-                        {item.quantity} × {item.name}
-                      </Text>
-                      {item.extras?.length ? (
-                        <Text allowFontScaling={false} style={styles.summaryItemExtras}>
-                          Extras: {item.extras.map((extra) => extra.name).join(', ')}
-                        </Text>
-                      ) : null}
-                    </View>
-                    <Text allowFontScaling={false} style={styles.summaryItemPrice}>
-                      {formatServerMoney(item.lineTotal)}
-                    </Text>
-                  </View>
-                ))}
-                {remainingItems > 0 ? (
-                  <Text allowFontScaling={false} style={styles.summaryMore}>
-                    + {remainingItems} more {remainingItems === 1 ? 'item' : 'items'}
-                  </Text>
-                ) : null}
-              </View>
-            ) : null}
-
-            <View style={styles.summaryActions}>
-              <TouchableOpacity
-                activeOpacity={0.88}
-                onPress={() => navigation.navigate('OrderHistory')}
-                style={[styles.actionButton, styles.actionButtonGhost]}
-              >
-                <Text allowFontScaling={false} style={styles.actionButtonGhostText}>
-                  View order history
-                </Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                activeOpacity={0.9}
-                onPress={() => navigation.navigate('Home')}
-                style={[styles.actionButton, styles.actionButtonPrimary]}
-              >
-                <Text allowFontScaling={false} style={styles.actionButtonPrimaryText}>
-                  Back to home
-                </Text>
-              </TouchableOpacity>
-            </View>
+          <View style={styles.summaryActions}>
+            <TouchableOpacity
+              activeOpacity={0.88}
+              onPress={() => navigation.navigate('OrderHistory')}
+              style={[styles.actionButton, styles.actionButtonGhost]}
+            >
+              <Text allowFontScaling={false} style={styles.actionButtonGhostText}>
+                View order history
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              activeOpacity={0.9}
+              onPress={() => navigation.navigate('Home')}
+              style={[styles.actionButton, styles.actionButtonPrimary]}
+            >
+              <Text allowFontScaling={false} style={styles.actionButtonPrimaryText}>
+                Back to home
+              </Text>
+            </TouchableOpacity>
           </View>
         </View>
-      </ScrollView>
-    </SafeAreaView>
+      </View>
+    </View>
+  );
+
+  return (
+    <MainLayout
+      showHeader
+      showFooter={false}
+      customHeader={heroHeader}
+      collapsedHeader={collapsedHeader}
+      mainContent={mainContent}
+      headerMaxHeight={360}
+      headerMinHeight={insets.top + 120}
+    />
   );
 };
 
 const styles = StyleSheet.create({
   hero: {
+    flex: 1,
+    width: '100%',
+    height: '100%',
     borderBottomLeftRadius: 36,
     borderBottomRightRadius: 36,
+  },
+  heroContent: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingBottom: 48,
+  },
+  heroTopRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  heroIconButton: {
+    height: 44,
+    width: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,255,255,0.2)',
+  },
+  orderChip: {
+    borderRadius: 9999,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  orderChipText: {
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 2,
+    color: 'rgba(255,255,255,0.9)',
+    textTransform: 'uppercase',
+  },
+  heroStatus: {
+    marginTop: 32,
+  },
+  heroNowLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 4,
+    textTransform: 'uppercase',
+    color: 'rgba(255,255,255,0.7)',
+  },
+  heroTitle: {
+    marginTop: 12,
+    fontSize: 32,
+    fontWeight: '700',
+    color: 'white',
+  },
+  heroDescription: {
+    marginTop: 16,
+    fontSize: 14,
+    lineHeight: 20,
+    color: 'rgba(255,255,255,0.85)',
   },
   heroSummary: {
     marginTop: 28,
@@ -647,6 +745,12 @@ const styles = StyleSheet.create({
   heroSummaryItem: {
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  heroSummaryText: {
+    marginLeft: 12,
+  },
+  heroSummarySpacer: {
+    marginTop: 16,
   },
   heroSummaryLabel: {
     fontSize: 12,
@@ -661,9 +765,14 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: heroDark,
   },
+  screenContent: {
+    flex: 1,
+    backgroundColor: softBackground,
+  },
   contentWrapper: {
     paddingHorizontal: 24,
     marginTop: -32,
+    paddingBottom: 40,
   },
   card: {
     borderRadius: 28,
@@ -687,6 +796,10 @@ const styles = StyleSheet.create({
     shadowRadius: 24,
     shadowOffset: { width: 0, height: 14 },
     elevation: 6,
+  },
+  contactInfo: {
+    flex: 1,
+    paddingRight: 16,
   },
   contactLabel: {
     color: 'rgba(255,255,255,0.7)',
@@ -714,12 +827,63 @@ const styles = StyleSheet.create({
     borderRadius: 9999,
     flexDirection: 'row',
     alignItems: 'center',
+    flexShrink: 0,
   },
   contactButtonText: {
     marginLeft: 8,
     color: 'white',
     fontSize: 13,
     fontWeight: '600',
+  },
+  collapsedHero: {
+    flex: 1,
+    width: '100%',
+    height: '100%',
+  },
+  collapsedHeaderContent: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+    paddingBottom: 12,
+  },
+  collapsedIconButton: {
+    height: 40,
+    width: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,255,255,0.18)',
+  },
+  collapsedHeaderText: {
+    flex: 1,
+    marginHorizontal: 16,
+  },
+  collapsedOrderId: {
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 1.5,
+    color: 'rgba(255,255,255,0.85)',
+    textTransform: 'uppercase',
+  },
+  collapsedTitle: {
+    marginTop: 4,
+    fontSize: 16,
+    fontWeight: '700',
+    color: 'white',
+  },
+  collapsedMeta: {
+    marginTop: 4,
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.8)',
+  },
+  collapsedCallButton: {
+    height: 40,
+    width: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'white',
   },
   mapCard: {
     marginTop: 24,

--- a/src/screens/RestaurantDetails.tsx
+++ b/src/screens/RestaurantDetails.tsx
@@ -28,6 +28,7 @@ import type {
 import { BASE_API_URL } from '@env';
 import { useCart } from '~/context/CartContext';
 import type { CartItem, CartItemOptionSelection } from '~/context/CartContext';
+import { vs } from 'react-native-size-matters';
 
 const { width, height: screenHeight } = Dimensions.get('screen');
 const modalHeight = screenHeight;
@@ -525,6 +526,8 @@ export default function RestaurantDetails() {
       <MainLayout
         showHeader
         showFooter
+        headerMaxHeight={vs(120)}
+        headerMinHeight={vs(110)}
         customHeader={customHeader}
         collapsedHeader={collapsedHeader}
         mainContent={mainContent()}


### PR DESCRIPTION
## Summary
- add a dedicated animated order tracking screen with a live progress timeline and order details
- update the checkout flow to navigate to the tracker after an order is created and remove the old confirmation overlay
- register the new tracker screen in the navigation stack for signed-in users

## Testing
- npm run lint *(fails: unresolved `@env` imports and other pre-existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_b_68dff8f2e20c832c99b66d1609c72418