### PR TITLE
Implement client order history fetch and adjust tracking timeline

### DIFF
--- a/src/api/orders.ts
+++ b/src/api/orders.ts
@@ -1,9 +1,14 @@
 import client from './client';
-import type { CreateOrderResponse, OrderRequest } from '~/interfaces/Order';
+import type { CreateOrderResponse, OrderDto, OrderRequest } from '~/interfaces/Order';
 
 export const createOrder = async (payload: OrderRequest) => {
   const { data } = await client.post<CreateOrderResponse>('/orders/create', payload);
   return data;
 };
 
-export type { CreateOrderResponse, OrderRequest };
+export const getMyOrders = async () => {
+  const { data } = await client.get<OrderDto[]>('/client/my-orders');
+  return data ?? [];
+};
+
+export type { CreateOrderResponse, OrderRequest, OrderDto };

--- a/src/interfaces/Order/index.ts
+++ b/src/interfaces/Order/index.ts
@@ -86,6 +86,38 @@ export interface OrderWorkflowStepDto {
   [key: string]: unknown;
 }
 
+export interface OrderItemDto {
+  menuItemId: number;
+  menuItemName: string;
+  quantity: number;
+  extras?: string[] | null;
+  specialInstructions?: string | null;
+}
+
+export interface OrderDto {
+  id: number;
+  restaurantName: string;
+  restaurantId: number;
+  restaurantAddress?: string | null;
+  restaurantLocation?: LocationDto | null;
+  restaurantPhone?: string | null;
+  clientId: number;
+  clientName: string;
+  clientPhone?: string | null;
+  clientAddress?: string | null;
+  clientLocation?: LocationDto | null;
+  savedAddress?: SavedAddressSummaryDto | null;
+  total: MonetaryAmount;
+  status: OrderStatus;
+  createdAt: string;
+  items: OrderItemDto[];
+  driverId?: number | null;
+  driverName?: string | null;
+  driverPhone?: string | null;
+  estimatedPickUpTime?: number | null;
+  estimatedDeliveryTime?: number | null;
+}
+
 export interface CreateOrderResponse {
   orderId: number;
   status: OrderStatus;

--- a/src/screens/OrderTracking.tsx
+++ b/src/screens/OrderTracking.tsx
@@ -743,12 +743,12 @@ const styles = StyleSheet.create({
     left: 17,
   },
   stepConnectorTop: {
-    top: -24,
-    bottom: 24,
+    top: 0,
+    bottom: 12,
   },
   stepConnectorBottom: {
-    top: 24,
-    bottom: -24,
+    top: 12,
+    bottom: 0,
   },
   stepConnectorActive: {
     backgroundColor: accentColor,

--- a/src/screens/Profile/OrderHistoryScreen.tsx
+++ b/src/screens/Profile/OrderHistoryScreen.tsx
@@ -1,14 +1,176 @@
-import React from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import React, { useMemo } from 'react';
+import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import { ArrowLeft, ClipboardList } from 'lucide-react-native';
+import { ArrowLeft } from 'lucide-react-native';
+import { useQuery } from '@tanstack/react-query';
 import { ScaledSheet, s, vs } from 'react-native-size-matters';
-import {Image} from 'expo-image';
+import { Image } from 'expo-image';
 
 import MainLayout from '~/layouts/MainLayout';
+import { getMyOrders } from '~/api/orders';
+import type { OrderDto } from '~/interfaces/Order';
+
+const accentColor = '#CA251B';
+const primaryColor = '#17213A';
+
+const emptyIllustration = require('../../../assets/emptyHistory.png');
+const orderPlaceholder = require('../../../assets/baguette.png');
+
+const formatOrderTotal = (total: OrderDto['total']) => {
+  if (total == null) {
+    return '--';
+  }
+
+  const parsed =
+    typeof total === 'string' ? Number(total.replace(/,/g, '.')) : Number(total);
+
+  if (!Number.isFinite(parsed)) {
+    return '--';
+  }
+
+  return `${parsed.toLocaleString('en-US', { minimumFractionDigits: 0 })} DT`;
+};
+
+const buildOrderSummary = (order: OrderDto) => {
+  if (!order?.items?.length) {
+    return order.restaurantAddress ?? 'Ready for pickup soon';
+  }
+
+  const entries = order.items
+    .filter((item) => item?.menuItemName)
+    .map((item) => {
+      const quantity = item.quantity && item.quantity > 1 ? `${item.quantity}x ` : '';
+      return `${quantity}${item.menuItemName}`;
+    });
+
+  if (!entries.length) {
+    return order.restaurantAddress ?? 'Ready for pickup soon';
+  }
+
+  const summary = entries.slice(0, 2).join(' • ');
+  const remaining = order.items.length - 2;
+  return remaining > 0 ? `${summary} • +${remaining} more` : summary;
+};
 
 const OrderHistoryScreen = () => {
   const navigation = useNavigation();
+
+  const { data, isLoading, isError, refetch, isFetching } = useQuery<OrderDto[]>({
+    queryKey: ['client', 'my-orders'],
+    queryFn: getMyOrders,
+  });
+
+  const orders = useMemo(() => {
+    if (!data?.length) {
+      return [] as OrderDto[];
+    }
+
+    const parseDate = (value?: string) => {
+      if (!value) {
+        return 0;
+      }
+
+      const timestamp = Date.parse(value);
+      return Number.isFinite(timestamp) ? timestamp : 0;
+    };
+
+    return [...data].sort((a, b) => parseDate(b.createdAt) - parseDate(a.createdAt));
+  }, [data]);
+
+  const hasOrders = orders.length > 0;
+
+  let content: React.ReactNode;
+
+  if (isLoading) {
+    content = (
+      <View style={styles.stateWrapper}>
+        <ActivityIndicator size="large" color={accentColor} />
+        <Text allowFontScaling={false} style={styles.stateTitle}>
+          Fetching your delicious memories...
+        </Text>
+      </View>
+    );
+  } else if (isError) {
+    content = (
+      <View style={styles.stateWrapper}>
+        <Text allowFontScaling={false} style={styles.stateTitle}>
+          We couldn’t load your orders.
+        </Text>
+        <Text allowFontScaling={false} style={styles.stateSubtitle}>
+          Check your connection and try again in a moment.
+        </Text>
+        <TouchableOpacity
+          activeOpacity={0.85}
+          style={styles.retryButton}
+          onPress={() => refetch()}
+        >
+          <Text allowFontScaling={false} style={styles.retryLabel}>Try again</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  } else if (!hasOrders) {
+    content = (
+      <View style={styles.emptyBody}>
+        <Image source={emptyIllustration} style={styles.emptyIllustration} contentFit="contain" />
+        <Text allowFontScaling={false} style={styles.emptyTitle}>
+          Your order history is empty
+        </Text>
+        <Text allowFontScaling={false} style={styles.emptySubtitle}>
+          Every great meal begins with a first click. Browse top-rated restaurants and build your flavor legacy today.
+        </Text>
+        <TouchableOpacity
+          activeOpacity={0.85}
+          style={styles.primaryButton}
+          onPress={() => navigation.navigate('Home' as never)}
+        >
+          <Text allowFontScaling={false} style={styles.primaryButtonLabel}>
+            Start Ordering
+          </Text>
+        </TouchableOpacity>
+      </View>
+    );
+  } else {
+    content = (
+      <View style={styles.ordersWrapper}>
+        {orders.map((order) => (
+          <View key={order.id} style={styles.orderCard}>
+            <Image source={orderPlaceholder} style={styles.orderImage} contentFit="cover" />
+            <View style={styles.orderContent}>
+              <Text allowFontScaling={false} style={styles.orderName} numberOfLines={1}>
+                {order.restaurantName}
+              </Text>
+              <Text allowFontScaling={false} style={styles.orderSummary} numberOfLines={2}>
+                {buildOrderSummary(order)}
+              </Text>
+              <View style={styles.orderFooter}>
+                <Text allowFontScaling={false} style={styles.orderTotal}>
+                  {formatOrderTotal(order.total)}
+                </Text>
+                <TouchableOpacity
+                  activeOpacity={0.85}
+                  style={styles.orderActionButton}
+                  onPress={() => navigation.navigate('OrderTracking' as never)}
+                >
+                  <Text allowFontScaling={false} style={styles.orderActionLabel}>
+                    See Details
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </View>
+        ))}
+        <TouchableOpacity
+          activeOpacity={0.9}
+          style={styles.continueButton}
+          onPress={() => navigation.navigate('Home' as never)}
+        >
+          <Text allowFontScaling={false} style={styles.continueLabel}>
+            Continue Ordering
+          </Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
 
   return (
     <MainLayout
@@ -22,9 +184,7 @@ const OrderHistoryScreen = () => {
             onPress={() => navigation.goBack()}
             activeOpacity={0.8}
           >
-            <Text allowFontScaling={false} style={styles.backSymbol}>
-              ?
-            </Text>
+            <ArrowLeft size={s(18)} color={accentColor} />
           </TouchableOpacity>
           <Text allowFontScaling={false} style={styles.headerTitle}>
             Order History
@@ -32,22 +192,9 @@ const OrderHistoryScreen = () => {
           <View style={{ width: s(32) }} />
         </View>
       }
-      mainContent={
-        <View style={styles.body}>
-          <Image source='../../assets/emptyHistory.png'/>
-          <Text allowFontScaling={false} style={styles.emptyTitle}>
-            Your order history is empty
-          </Text>
-          <Text allowFontScaling={false} style={styles.emptySubtitle}>
-            Every great meal begins with a first click. Browse top-rated restaurants and build your flavor legacy today.
-          </Text>
-          <TouchableOpacity activeOpacity={0.85} style={styles.primaryButton} onPress={() => navigation.navigate('Home' as never)}>
-            <Text allowFontScaling={false} style={styles.primaryButtonLabel}>
-              Start Ordering
-            </Text>
-          </TouchableOpacity>
-        </View>
-      }
+      mainContent={content}
+      onRefresh={refetch}
+      isRefreshing={isFetching}
     />
   );
 };
@@ -65,16 +212,16 @@ const styles = ScaledSheet.create({
     width: '32@s',
     height: '32@s',
     borderRadius: '16@s',
-    backgroundColor: 'rgba(202,37,27,0.12)',
+    backgroundColor: 'rgba(202,37,27,0.1)',
     alignItems: 'center',
     justifyContent: 'center',
   },
   headerTitle: {
     fontSize: '16@ms',
     fontWeight: '700',
-    color: '#17213A',
+    color: primaryColor,
   },
-  body: {
+  stateWrapper: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
@@ -82,35 +229,47 @@ const styles = ScaledSheet.create({
     paddingBottom: '32@vs',
     gap: '16@vs',
   },
-  illustrationCircle: {
-    width: '140@s',
-    height: '140@s',
-    borderRadius: '70@s',
-    backgroundColor: 'rgba(202,37,27,0.08)',
-    alignItems: 'center',
-    justifyContent: 'center',
-    position: 'relative',
-  },
-  badge: {
-    position: 'absolute',
-    right: '18@s',
-    top: '18@vs',
-    backgroundColor: '#CA251B',
-    width: '36@s',
-    height: '36@s',
-    borderRadius: '18@s',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  badgeText: {
-    color: '#FFFFFF',
+  stateTitle: {
     fontSize: '16@ms',
+    fontWeight: '600',
+    color: primaryColor,
+    textAlign: 'center',
+  },
+  stateSubtitle: {
+    fontSize: '13@ms',
+    color: '#4B5563',
+    textAlign: 'center',
+    lineHeight: '20@vs',
+    paddingHorizontal: '12@s',
+  },
+  retryButton: {
+    marginTop: '8@vs',
+    backgroundColor: accentColor,
+    paddingHorizontal: '24@s',
+    paddingVertical: '10@vs',
+    borderRadius: '20@ms',
+  },
+  retryLabel: {
+    color: '#FFFFFF',
+    fontSize: '14@ms',
     fontWeight: '700',
+  },
+  emptyBody: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: '24@s',
+    paddingBottom: '32@vs',
+    gap: '16@vs',
+  },
+  emptyIllustration: {
+    width: '220@s',
+    height: '180@vs',
   },
   emptyTitle: {
     fontSize: '18@ms',
     fontWeight: '700',
-    color: '#17213A',
+    color: primaryColor,
     textAlign: 'center',
   },
   emptySubtitle: {
@@ -122,7 +281,7 @@ const styles = ScaledSheet.create({
   },
   primaryButton: {
     marginTop: '12@vs',
-    backgroundColor: '#17213A',
+    backgroundColor: primaryColor,
     paddingHorizontal: '28@s',
     paddingVertical: '12@vs',
     borderRadius: '22@ms',
@@ -131,6 +290,80 @@ const styles = ScaledSheet.create({
     color: '#FFFFFF',
     fontSize: '14@ms',
     fontWeight: '700',
+  },
+  ordersWrapper: {
+    flex: 1,
+    paddingHorizontal: '16@s',
+    paddingBottom: '32@vs',
+    paddingTop: '8@vs',
+    gap: '16@vs',
+  },
+  orderCard: {
+    flexDirection: 'row',
+    backgroundColor: '#FFFFFF',
+    borderRadius: '18@ms',
+    padding: '12@s',
+    alignItems: 'center',
+    shadowColor: 'rgba(15,23,42,0.08)',
+    shadowOpacity: 0.12,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 3,
+    gap: '12@s',
+  },
+  orderImage: {
+    width: '72@s',
+    height: '72@s',
+    borderRadius: '16@s',
+  },
+  orderContent: {
+    flex: 1,
+    gap: '6@vs',
+  },
+  orderName: {
+    fontSize: '15@ms',
+    fontWeight: '700',
+    color: primaryColor,
+  },
+  orderSummary: {
+    fontSize: '12@ms',
+    color: '#6B7280',
+  },
+  orderFooter: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '12@s',
+  },
+  orderTotal: {
+    fontSize: '15@ms',
+    fontWeight: '700',
+    color: primaryColor,
+  },
+  orderActionButton: {
+    backgroundColor: accentColor,
+    paddingHorizontal: '16@s',
+    paddingVertical: '8@vs',
+    borderRadius: '18@ms',
+  },
+  orderActionLabel: {
+    color: '#FFFFFF',
+    fontSize: '12@ms',
+    fontWeight: '700',
+  },
+  continueButton: {
+    marginTop: '8@vs',
+    backgroundColor: primaryColor,
+    paddingVertical: '14@vs',
+    borderRadius: '24@ms',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  continueLabel: {
+    color: '#FFFFFF',
+    fontSize: '14@ms',
+    fontWeight: '700',
+    letterSpacing: 0.3,
   },
 });
 


### PR DESCRIPTION
## Summary
- add DTO types and a client method for retrieving /client/my-orders results
- redesign the order history screen to consume the API and render list/empty/error states
- tweak order tracking timeline connector styling so the step lines appear continuous

## Testing
- npm run lint *(fails: existing unresolved @env imports and lint warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68e03e5ea880832c91fa85c31cd46769