### PR TITLE
Connect search UI to backend search endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.2",
+        "@react-native-community/slider": "^5.0.1",
         "@react-navigation/native-stack": "^7.3.26",
         "@stomp/stompjs": "^7.2.0",
         "@tanstack/react-query": "^5.90.2",
@@ -2994,6 +2995,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@react-native-community/slider": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-5.0.1.tgz",
+      "integrity": "sha512-K3JRWkIW4wQ79YJ6+BPZzp1SamoikxfPRw7Yw4B4PElEQmqZFrmH9M5LxvIo460/3QSrZF/wCgi3qizJt7g/iw==",
+      "license": "MIT"
     },
     "node_modules/@react-native/assets-registry": {
       "version": "0.81.4",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -8,7 +8,7 @@ export const setAccessToken = (token: string | null) => {
 };
 
 const client = axios.create({
-  baseURL: BASE_API_URL,
+  baseURL: BASE_API_URL + '',
   timeout: 10000,
 });
 

--- a/src/api/restaurants.ts
+++ b/src/api/restaurants.ts
@@ -2,6 +2,8 @@ import client from './client';
 import type {
   NearbyRestaurantsParams,
   RestaurantDetailsResponse,
+  RestaurantSearchParams,
+  RestaurantSearchResponse,
   RestaurantSummary,
 } from '~/interfaces/Restaurant';
 
@@ -19,5 +21,15 @@ export const getNearbyRestaurants = async ({ lat, lng, radiusKm = 1 }: NearbyRes
 
 export const getRestaurantDetails = async (id: number): Promise<RestaurantDetailsResponse> => {
   const { data } = await client.get<RestaurantDetailsResponse>(`/client/restaurant/${id}`);
+  return data;
+};
+
+export const searchRestaurants = async (
+  params: RestaurantSearchParams
+): Promise<RestaurantSearchResponse> => {
+  const { data } = await client.get<RestaurantSearchResponse>(`/client/restaurants/search`, {
+    params,
+  });
+
   return data;
 };

--- a/src/components/FiltersOverlay.tsx
+++ b/src/components/FiltersOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   View,
   Text,
@@ -15,18 +15,41 @@ interface FiltersOverlayProps {
   visible: boolean;
   onClose: () => void;
   onApply?: (filters: { sort: string; topEat: boolean; maxFee: number }) => void;
+  onClearAll?: () => void;
+  initialFilters?: {
+    sort: string;
+    topEat: boolean;
+    maxFee: number;
+  };
 }
 
-export default function FiltersOverlay({ visible, onClose, onApply }: FiltersOverlayProps) {
+export default function FiltersOverlay({
+  visible,
+  onClose,
+  onApply,
+  onClearAll,
+  initialFilters,
+}: FiltersOverlayProps) {
   const feeSteps = [1, 1.5, 2, 2.5];
-  const [maxFee, setMaxFee] = useState(1.5);
-  const [sortOption, setSortOption] = useState("picked");
-  const [topEat, setTopEat] = useState(true);
+  const [maxFee, setMaxFee] = useState(initialFilters?.maxFee ?? 1.5);
+  const [sortOption, setSortOption] = useState(initialFilters?.sort ?? "picked");
+  const [topEat, setTopEat] = useState(initialFilters?.topEat ?? false);
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+
+    setSortOption(initialFilters?.sort ?? "picked");
+    setTopEat(initialFilters?.topEat ?? false);
+    setMaxFee(initialFilters?.maxFee ?? 1.5);
+  }, [visible, initialFilters]);
 
   const clearAll = () => {
     setSortOption("picked");
-    setTopEat(true);
+    setTopEat(false);
     setMaxFee(1.5);
+    onClearAll?.();
   };
 
   const applyFilters = () => {

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+export default function useDebounce<T>(value: T, delay = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handle);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/src/interfaces/Restaurant/index.ts
+++ b/src/interfaces/Restaurant/index.ts
@@ -127,4 +127,5 @@ export interface MenuItemPromotion {
   price: number;
   promotionPrice?: number | null;
   promotionLabel?: string | null;
+  imageUrl: string;
 }

--- a/src/interfaces/Restaurant/index.ts
+++ b/src/interfaces/Restaurant/index.ts
@@ -111,6 +111,7 @@ export interface RestaurantSearchItem {
   hasFreeDelivery: boolean;
   promotionLabel?: string | null;
   imageUrl: string;
+  promotedMenuItems?: MenuItemPromotion[];
 }
 
 export interface RestaurantSearchResponse {
@@ -118,4 +119,12 @@ export interface RestaurantSearchResponse {
   page: number;
   pageSize: number;
   totalItems: number;
+}
+
+export interface MenuItemPromotion {
+  id: number;
+  name: string;
+  price: number;
+  promotionPrice?: number | null;
+  promotionLabel?: string | null;
 }

--- a/src/interfaces/Restaurant/index.ts
+++ b/src/interfaces/Restaurant/index.ts
@@ -87,3 +87,35 @@ export interface NearbyRestaurantsParams {
   lng: number;
   radiusKm?: number;
 }
+
+export type RestaurantSearchSort = "picked" | "popular" | "rating";
+
+export interface RestaurantSearchParams {
+  query?: string;
+  hasPromotion?: boolean;
+  isTopChoice?: boolean;
+  hasFreeDelivery?: boolean;
+  sort?: RestaurantSearchSort;
+  topEatOnly?: boolean;
+  maxDeliveryFee?: number;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface RestaurantSearchItem {
+  id: number;
+  name: string;
+  deliveryTimeRange: string;
+  rating: number;
+  isTopChoice: boolean;
+  hasFreeDelivery: boolean;
+  promotionLabel?: string | null;
+  imageUrl: string;
+}
+
+export interface RestaurantSearchResponse {
+  items: RestaurantSearchItem[];
+  page: number;
+  pageSize: number;
+  totalItems: number;
+}

--- a/src/interfaces/Restaurant/index.ts
+++ b/src/interfaces/Restaurant/index.ts
@@ -28,6 +28,9 @@ export interface RestaurantMenuItemDetails {
   popular: boolean;
   tags: string[];
   optionGroups: RestaurantMenuOptionGroup[];
+  promotionActive?: boolean;
+  promotionPrice?: number | null;
+  promotionLabel?: string | null;
 }
 
 export interface RestaurantMenuCategory {
@@ -43,6 +46,9 @@ export interface RestaurantMenuItemSummary {
   imageUrl: string;
   popular: boolean;
   tags: string[];
+  promotionActive?: boolean;
+  promotionPrice?: number | null;
+  promotionLabel?: string | null;
 }
 
 export interface RestaurantDetailsResponse {

--- a/src/interfaces/Restaurant/index.ts
+++ b/src/interfaces/Restaurant/index.ts
@@ -109,7 +109,6 @@ export interface RestaurantSearchItem {
   rating: number;
   isTopChoice: boolean;
   hasFreeDelivery: boolean;
-  promotionLabel?: string | null;
   imageUrl: string;
   promotedMenuItems?: MenuItemPromotion[];
 }

--- a/src/screens/OrderTracking.tsx
+++ b/src/screens/OrderTracking.tsx
@@ -202,8 +202,8 @@ const mergeOrderData = (
     ...(baseOrder?.payment || update?.payment
       ? {
           payment: {
-            ...((baseOrder?.payment as Record<string, unknown>) ?? {}),
-            ...((update?.payment as Record<string, unknown>) ?? {}),
+            ...((baseOrder?.payment as unknown as Record<string, unknown>) ?? {}),
+            ...((update?.payment as unknown as Record<string, unknown>) ?? {}),
           },
         }
       : {}),
@@ -211,7 +211,7 @@ const mergeOrderData = (
     workflow: update?.workflow ?? baseOrder?.workflow,
     statusHistory: update?.statusHistory ?? baseOrder?.statusHistory,
     status: update?.status ?? baseOrder?.status,
-    orderId: update?.orderId ?? baseOrder?.orderId ?? null,
+    orderId: update?.orderId ?? baseOrder?.orderId,
   };
 
   if (merged.orderId == null && baseOrder?.orderId != null) {
@@ -676,12 +676,12 @@ const OrderTrackingScreen: React.FC = () => {
                 const isLast = index === (order?.items?.length ?? 0) - 1;
                 return (
                   <View
-                    key={`${item.menuItem?.id ?? index}-${index}`}
+                    key={`${item?.menuItemId ?? index}-${index}`}
                     style={[styles.summaryItemRow, !isLast && styles.summaryItemRowSpacing]}
                   >
                     <Text style={styles.summaryItemQuantity}>{item.quantity ?? 1}x</Text>
                     <Text style={styles.summaryItemName} numberOfLines={1}>
-                      {item.menuItem?.name ?? item.name ?? 'Menu item'}
+                      {item?.name ?? item.name ?? 'Menu item'}
                     </Text>
                   </View>
                 );

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -75,15 +75,7 @@ const PillButton = ({ label, icon: Icon, onPress, isActive = false }: PillButton
 const formatCurrency = (value: number) => `${value.toFixed(3).replace(".", ",")} DT`;
 
 const RestaurantCard = ({ data }: { data: RestaurantSearchItem }) => {
-  const {
-    name,
-    deliveryTimeRange,
-    rating,
-    isTopChoice,
-    hasFreeDelivery,
-    promotionLabel,
-    imageUrl,
-  } = data;
+  const { name, deliveryTimeRange, rating, isTopChoice, hasFreeDelivery, imageUrl } = data;
 
   const imageSource = imageUrl ? { uri: imageUrl } : FALLBACK_IMAGE;
   const formattedRating = Number.isFinite(rating) ? `${rating}/5` : "-";
@@ -95,12 +87,6 @@ const RestaurantCard = ({ data }: { data: RestaurantSearchItem }) => {
       {isTopChoice && (
         <View style={styles.badgeTopRight}>
           <Star size={s(16)} color="white" fill="#CA251B" />
-        </View>
-      )}
-
-      {promotionLabel && (
-        <View style={styles.discountBadge}>
-          <Text style={styles.discountText}>{promotionLabel}</Text>
         </View>
       )}
 
@@ -503,22 +489,6 @@ const styles = ScaledSheet.create({
     borderRadius: "50@ms",
     padding: "4@s",
     elevation: 3,
-  },
-  discountBadge: {
-    position: "absolute",
-    top: "10@vs",
-    right: "10@s",
-    backgroundColor: "#CA251B",
-    borderRadius: "8@ms",
-    paddingHorizontal: "8@s",
-    paddingVertical: "4@vs",
-    elevation: 3,
-  },
-  discountText: {
-    color: "white",
-    fontFamily: "Roboto",
-    fontSize: "14@ms",
-    fontWeight: "700",
   },
   cardBody: { padding: "10@s" },
   cardTitle: {

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -70,11 +70,23 @@ const PillButton = ({ label, icon: Icon, onPress, isActive = false }: PillButton
   );
 };
 
+const formatCurrency = (value: number) => `${value.toFixed(3).replace(".", ",")} DT`;
+
 const RestaurantCard = ({ data }: { data: RestaurantSearchItem }) => {
-  const { name, deliveryTimeRange, rating, isTopChoice, hasFreeDelivery, promotionLabel, imageUrl } = data;
+  const {
+    name,
+    deliveryTimeRange,
+    rating,
+    isTopChoice,
+    hasFreeDelivery,
+    promotionLabel,
+    imageUrl,
+    promotedMenuItems,
+  } = data;
 
   const imageSource = imageUrl ? { uri: imageUrl } : FALLBACK_IMAGE;
   const formattedRating = Number.isFinite(rating) ? `${rating}/5` : "-";
+  const highlightedItems = (promotedMenuItems ?? []).slice(0, 3);
 
   return (
     <TouchableOpacity style={styles.card} activeOpacity={0.9}>
@@ -107,6 +119,44 @@ const RestaurantCard = ({ data }: { data: RestaurantSearchItem }) => {
             <View style={styles.freeDeliveryPill}>
               <Text style={styles.promoText}>Free Delivery</Text>
             </View>
+          </View>
+        )}
+
+        {highlightedItems.length > 0 && (
+          <View style={styles.promotedSection}>
+            <Text style={styles.promotedTitle}>Menu promotions</Text>
+            {highlightedItems.map((item) => {
+              const hasPromoPrice =
+                typeof item.promotionPrice === "number" && Number.isFinite(item.promotionPrice);
+
+              return (
+                <View key={item.id} style={styles.promotedItemRow}>
+                  <View style={styles.promotedItemInfo}>
+                    <Text style={styles.promotedItemName} numberOfLines={1}>
+                      {item.name}
+                    </Text>
+                    {item.promotionLabel && (
+                      <Text style={styles.promotedItemLabel}>{item.promotionLabel}</Text>
+                    )}
+                  </View>
+
+                  <View style={styles.promotedPriceColumn}>
+                    {hasPromoPrice ? (
+                      <>
+                        <Text style={styles.promotedOriginalPrice}>
+                          {formatCurrency(item.price)}
+                        </Text>
+                        <Text style={styles.promotedPrice}>
+                          {formatCurrency(item.promotionPrice ?? item.price)}
+                        </Text>
+                      </>
+                    ) : (
+                      <Text style={styles.promotedPrice}>{formatCurrency(item.price)}</Text>
+                    )}
+                  </View>
+                </View>
+              );
+            })}
           </View>
         )}
       </View>
@@ -470,6 +520,54 @@ const styles = ScaledSheet.create({
     fontFamily: "Roboto",
     fontSize: "13@ms",
     fontWeight: "600",
+  },
+  promotedSection: {
+    marginTop: "12@vs",
+    borderTopWidth: 1,
+    borderTopColor: "#F3F4F6",
+    paddingTop: "10@vs",
+    gap: "8@vs",
+  },
+  promotedTitle: {
+    fontFamily: "Roboto",
+    fontSize: "13@ms",
+    fontWeight: "700",
+    color: "#111827",
+  },
+  promotedItemRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: "12@s",
+  },
+  promotedItemInfo: { flex: 1 },
+  promotedItemName: {
+    fontFamily: "Roboto",
+    fontSize: "13.5@ms",
+    fontWeight: "600",
+    color: "#1F2937",
+  },
+  promotedItemLabel: {
+    fontFamily: "Roboto",
+    fontSize: "12@ms",
+    fontWeight: "500",
+    color: "#CA251B",
+    marginTop: "2@vs",
+  },
+  promotedPriceColumn: {
+    alignItems: "flex-end",
+  },
+  promotedOriginalPrice: {
+    fontFamily: "Roboto",
+    fontSize: "11.5@ms",
+    color: "#9CA3AF",
+    textDecorationLine: "line-through",
+  },
+  promotedPrice: {
+    fontFamily: "Roboto",
+    fontSize: "13.5@ms",
+    fontWeight: "700",
+    color: "#047857",
   },
   stateContainer: {
     alignItems: "center",

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -149,6 +149,28 @@ const PromotedMenuItemCard = ({
   );
 };
 
+const RestaurantResult = ({ restaurant }: { restaurant: RestaurantSearchItem }) => {
+  const promotions = restaurant.promotedMenuItems ?? [];
+
+  return (
+    <View style={styles.restaurantResult}>
+      <RestaurantCard data={restaurant} />
+      {promotions.length > 0 && (
+        <View style={styles.promotedMenuList}>
+          <Text style={styles.promotedMenuHeading}>Promoted items</Text>
+          {promotions.map((item) => (
+            <PromotedMenuItemCard
+              key={`promotion-${restaurant.id}-${item.id}`}
+              item={item}
+              restaurantName={restaurant.name}
+            />
+          ))}
+        </View>
+      )}
+    </View>
+  );
+};
+
 export default function SearchScreen() {
   const navigation = useNavigation<NavigationProp<ParamListBase>>();
 
@@ -208,38 +230,6 @@ export default function SearchScreen() {
 
   const restaurants = data?.items ?? [];
   const totalItems = data?.totalItems ?? 0;
-
-  const combinedResults = useMemo(
-    () =>
-      restaurants.flatMap((restaurant) => {
-        const entries: (
-          | { type: "restaurant"; restaurant: RestaurantSearchItem }
-          | {
-              type: "promotion";
-              restaurantId: number;
-              restaurantName: string;
-              item: MenuItemPromotion;
-            }
-        )[] = [
-          {
-            type: "restaurant",
-            restaurant,
-          },
-        ];
-
-        (restaurant.promotedMenuItems ?? []).forEach((item) => {
-          entries.push({
-            type: "promotion",
-            restaurantId: restaurant.id,
-            restaurantName: restaurant.name,
-            item,
-          });
-        });
-
-        return entries;
-      }),
-    [restaurants]
-  );
 
   const showResultCount = useMemo(() => {
     const baseQueryActive = debouncedSearchTerm.trim().length > 0;
@@ -341,17 +331,9 @@ export default function SearchScreen() {
             <Text style={styles.stateText}>No restaurants match your filters yet.</Text>
           </View>
         ) : (
-          combinedResults.map((entry) =>
-            entry.type === "restaurant" ? (
-              <RestaurantCard key={`restaurant-${entry.restaurant.id}`} data={entry.restaurant} />
-            ) : (
-              <PromotedMenuItemCard
-                key={`promotion-${entry.restaurantId}-${entry.item.id}`}
-                item={entry.item}
-                restaurantName={entry.restaurantName}
-              />
-            )
-          )
+          restaurants.map((restaurant) => (
+            <RestaurantResult key={`restaurant-${restaurant.id}`} restaurant={restaurant} />
+          ))
         )}
       </View>
     </View>
@@ -467,6 +449,15 @@ const styles = ScaledSheet.create({
     fontWeight: "500",
   },
   cardList: { gap: "16@vs" },
+  restaurantResult: { gap: "12@vs" },
+  promotedMenuList: { gap: "12@vs", marginTop: "6@vs" },
+  promotedMenuHeading: {
+    fontFamily: "Roboto",
+    fontSize: "13@ms",
+    fontWeight: "600",
+    color: "#CA251B",
+    marginLeft: "6@s",
+  },
   card: {
     backgroundColor: "white",
     borderRadius: "12@ms",

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -1,45 +1,61 @@
-import React, { useState, useMemo } from "react";
-import { View, Text, TouchableOpacity, ScrollView, TextInput, Image } from "react-native";
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  ScrollView,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+  Image,
+} from "react-native";
+import { useQuery } from "@tanstack/react-query";
+import { NavigationProp, ParamListBase, useNavigation } from "@react-navigation/native";
 import { ScaledSheet, s, vs } from "react-native-size-matters";
 import { Search, SlidersHorizontal, Star } from "lucide-react-native";
 import Animated, { FadeIn } from "react-native-reanimated";
 import MainLayout from "~/layouts/MainLayout";
 import Header from "~/components/Header";
-import { NavigationProp, ParamListBase, useNavigation } from "@react-navigation/native";
 import FiltersOverlay from "~/components/FiltersOverlay";
+import useDebounce from "~/hooks/useDebounce";
+import { searchRestaurants } from "~/api/restaurants";
+import type {
+  RestaurantSearchItem,
+  RestaurantSearchParams,
+  RestaurantSearchSort,
+} from "~/interfaces/Restaurant";
 
-const image1 = require("../../assets/TEST.png");
-const image2 = require("../../assets/baguette.png");
-const image3 = require("../../assets/TEST.png");
+const FALLBACK_IMAGE = require("../../assets/TEST.png");
+const PAGE = 1;
+const PAGE_SIZE = 20;
 
-interface RestaurantData {
-  id: number;
-  name: string;
-  time: string;
-  rating: number;
-  isTopChoice?: boolean;
-  isFreeDelivery?: boolean;
-  discount?: string;
-  image: any;
-}
+const QUICK_FILTERS_DEFAULT = Object.freeze({
+  promotions: false,
+  topChoice: false,
+  freeDelivery: false,
+});
 
-const mockSearchResults: RestaurantData[] = [
-  { id: 1, name: "Da Pietro", time: "15-25 min", rating: 4.5, isTopChoice: true, image: image1 },
-  { id: 2, name: "Papa Jones", time: "15-25 min", rating: 4.5, isFreeDelivery: true, image: image2 },
-  { id: 3, name: "Papa Jones", time: "15-25 min", rating: 4.5, discount: "20%", image: image3 },
-];
+const OVERLAY_FILTERS_DEFAULT = Object.freeze({
+  sort: "picked" as RestaurantSearchSort,
+  topEat: false,
+  maxFee: 1.5,
+});
 
-const PillButton = ({
-  label,
-  icon: Icon,
-  onPress,
-  isActive = false,
-}: {
+type QuickFilterKey = keyof typeof QUICK_FILTERS_DEFAULT;
+
+type OverlayFiltersState = {
+  sort: RestaurantSearchSort;
+  topEat: boolean;
+  maxFee: number;
+};
+
+interface PillButtonProps {
   label?: string;
   icon?: any;
   onPress: () => void;
   isActive?: boolean;
-}) => {
+}
+
+const PillButton = ({ label, icon: Icon, onPress, isActive = false }: PillButtonProps) => {
   const buttonStyle = [styles.pillButton, isActive && styles.pillActive];
   const textStyle = isActive ? styles.pillTextActive : styles.pillText;
   const iconColor = textStyle.color;
@@ -47,23 +63,22 @@ const PillButton = ({
   return (
     <TouchableOpacity onPress={onPress} style={buttonStyle} activeOpacity={0.85}>
       {Icon && (
-        <Icon
-          size={s(20)}
-          color={iconColor}
-          style={{ marginRight: label ? s(4) : 0 }}
-        />
+        <Icon size={s(20)} color={iconColor} style={{ marginRight: label ? s(4) : 0 }} />
       )}
       {label && <Text style={textStyle}>{label}</Text>}
     </TouchableOpacity>
   );
 };
 
-const RestaurantCard = ({ data }: { data: RestaurantData }) => {
-  const { name, time, rating, isTopChoice, isFreeDelivery, discount, image } = data;
+const RestaurantCard = ({ data }: { data: RestaurantSearchItem }) => {
+  const { name, deliveryTimeRange, rating, isTopChoice, hasFreeDelivery, promotionLabel, imageUrl } = data;
+
+  const imageSource = imageUrl ? { uri: imageUrl } : FALLBACK_IMAGE;
+  const formattedRating = Number.isFinite(rating) ? `${rating}/5` : "-";
 
   return (
     <TouchableOpacity style={styles.card} activeOpacity={0.9}>
-      <Image source={image} style={styles.cardImage} />
+      <Image source={imageSource} style={styles.cardImage} />
 
       {isTopChoice && (
         <View style={styles.badgeTopRight}>
@@ -71,23 +86,23 @@ const RestaurantCard = ({ data }: { data: RestaurantData }) => {
         </View>
       )}
 
-      {discount && (
+      {promotionLabel && (
         <View style={styles.discountBadge}>
-          <Text style={styles.discountText}>{discount}</Text>
+          <Text style={styles.discountText}>{promotionLabel}</Text>
         </View>
       )}
 
       <View style={styles.cardBody}>
         <Text style={styles.cardTitle}>{name}</Text>
         <View style={styles.timeRatingRow}>
-          <Text style={styles.deliveryTime}>{time}</Text>
+          <Text style={styles.deliveryTime}>{deliveryTimeRange}</Text>
           <View style={styles.ratingRow}>
             <Star size={s(14)} color="#FACC15" fill="#FACC15" />
-            <Text style={styles.ratingText}>{rating}/5</Text>
+            <Text style={styles.ratingText}>{formattedRating}</Text>
           </View>
         </View>
 
-        {isFreeDelivery && (
+        {hasFreeDelivery && (
           <View style={styles.promoContainer}>
             <View style={styles.freeDeliveryPill}>
               <Text style={styles.promoText}>Free Delivery</Text>
@@ -100,37 +115,78 @@ const RestaurantCard = ({ data }: { data: RestaurantData }) => {
 };
 
 export default function SearchScreen() {
-  const [searchTerm, setSearchTerm] = useState<string>("");
-  const [showFilters, setShowFilters] = useState(false);
-
   const navigation = useNavigation<NavigationProp<ParamListBase>>();
 
-  const [filters, setFilters] = useState({
-    filter: false,
-    promotions: false,
-    topChoice: false,
-    freeDelivery: false,
+  const [searchTerm, setSearchTerm] = useState<string>("");
+  const [showFilters, setShowFilters] = useState(false);
+  const [quickFilters, setQuickFilters] = useState(() => ({ ...QUICK_FILTERS_DEFAULT }));
+  const [overlayFilters, setOverlayFilters] = useState<OverlayFiltersState>(() => ({
+    ...OVERLAY_FILTERS_DEFAULT,
+  }));
+
+  const debouncedSearchTerm = useDebounce(searchTerm, 300);
+
+  const toggleQuickFilter = useCallback((key: QuickFilterKey) => {
+    setQuickFilters((prev) => ({ ...prev, [key]: !prev[key] }));
+  }, []);
+
+  const handleApplyOverlayFilters = useCallback(
+    (next: { sort: string; topEat: boolean; maxFee: number }) => {
+      setOverlayFilters({
+        sort: next.sort as RestaurantSearchSort,
+        topEat: next.topEat,
+        maxFee: next.maxFee,
+      });
+    },
+    []
+  );
+
+  const handleClearAll = useCallback(() => {
+    setQuickFilters({ ...QUICK_FILTERS_DEFAULT });
+    setOverlayFilters({ ...OVERLAY_FILTERS_DEFAULT });
+  }, []);
+
+  const { promotions, topChoice, freeDelivery } = quickFilters;
+  const { sort, topEat, maxFee } = overlayFilters;
+
+  const queryParams = useMemo<RestaurantSearchParams>(() => {
+    const trimmedQuery = debouncedSearchTerm.trim();
+
+    return {
+      query: trimmedQuery,
+      hasPromotion: promotions,
+      isTopChoice: topChoice,
+      hasFreeDelivery: freeDelivery,
+      sort,
+      topEatOnly: topEat,
+      maxDeliveryFee: maxFee,
+      page: PAGE,
+      pageSize: PAGE_SIZE,
+    };
+  }, [debouncedSearchTerm, promotions, topChoice, freeDelivery, sort, topEat, maxFee]);
+
+  const { data, isLoading, isError, isFetching, refetch } = useQuery({
+    queryKey: ["restaurants-search", queryParams],
+    queryFn: () => searchRestaurants(queryParams),
+    keepPreviousData: true,
   });
 
-  const toggleFilter = (key: keyof typeof filters) =>
-    setFilters((prev) => ({ ...prev, [key]: !prev[key] }));
+  const restaurants = data?.items ?? [];
+  const totalItems = data?.totalItems ?? 0;
 
-  const filteredResults = useMemo(() => {
-    const term = (searchTerm ?? "").trim().toLowerCase();
-    const anyFilterActive = filters.topChoice || filters.freeDelivery || filters.promotions;
+  const showResultCount = useMemo(() => {
+    const baseQueryActive = debouncedSearchTerm.trim().length > 0;
+    const quickFiltersActive = promotions || topChoice || freeDelivery;
+    const overlayChanged =
+      sort !== OVERLAY_FILTERS_DEFAULT.sort ||
+      topEat !== OVERLAY_FILTERS_DEFAULT.topEat ||
+      maxFee !== OVERLAY_FILTERS_DEFAULT.maxFee;
 
-    return mockSearchResults.filter((item) => {
-      const name = (item.name ?? "").toLowerCase();
-      const matchText = term.length === 0 || name.includes(term);
-      const matchFilter =
-        !anyFilterActive ||
-        (filters.topChoice && !!item.isTopChoice) ||
-        (filters.freeDelivery && !!item.isFreeDelivery) ||
-        (filters.promotions && !!item.discount);
+    return baseQueryActive || quickFiltersActive || overlayChanged;
+  }, [debouncedSearchTerm, promotions, topChoice, freeDelivery, sort, topEat, maxFee]);
 
-      return matchText && matchFilter;
-    });
-  }, [searchTerm, filters]);
+  const showInlineSpinner = isFetching && !isLoading;
+  const isEmpty = !isLoading && !isFetching && !isError && restaurants.length === 0;
 
   const customHeader = (
     <Animated.View entering={FadeIn.duration(500)} style={styles.headerWrapper}>
@@ -141,7 +197,6 @@ export default function SearchScreen() {
         compact
       />
 
-      {/* Search Bar */}
       <View style={styles.searchBarContainer}>
         <View style={styles.searchBar}>
           <TextInput
@@ -150,39 +205,35 @@ export default function SearchScreen() {
             value={searchTerm}
             onChangeText={setSearchTerm}
             placeholderTextColor="#666"
+            autoCorrect={false}
+            returnKeyType="search"
           />
           <Search size={s(18)} color="black" />
         </View>
       </View>
 
-      {/* Filter Pills */}
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
         style={{ marginTop: vs(20) }}
         contentContainerStyle={styles.pillsContainer}
       >
-        <PillButton
-  icon={SlidersHorizontal}
-  onPress={() => setShowFilters(true)}
-  isActive={showFilters}
-/>
-
+        <PillButton icon={SlidersHorizontal} onPress={() => setShowFilters(true)} isActive={showFilters} />
 
         <PillButton
           label="Promotions"
-          onPress={() => toggleFilter("promotions")}
-          isActive={filters.promotions}
+          onPress={() => toggleQuickFilter("promotions")}
+          isActive={promotions}
         />
         <PillButton
           label="Top Choice"
-          onPress={() => toggleFilter("topChoice")}
-          isActive={filters.topChoice}
+          onPress={() => toggleQuickFilter("topChoice")}
+          isActive={topChoice}
         />
         <PillButton
           label="Free Delivery"
-          onPress={() => toggleFilter("freeDelivery")}
-          isActive={filters.freeDelivery}
+          onPress={() => toggleQuickFilter("freeDelivery")}
+          isActive={freeDelivery}
         />
       </ScrollView>
     </Animated.View>
@@ -191,45 +242,65 @@ export default function SearchScreen() {
   const mainContent = (
     <View style={styles.mainWrapper}>
       <View style={{ height: vs(10) }} />
-      {searchTerm.trim().length > 0 && (
+
+      {showResultCount && (
         <Text style={styles.resultsCount}>
-          {filteredResults.length} Results for “{searchTerm}”
+          {isLoading ? "Searching..." : `${totalItems} Results${debouncedSearchTerm ? ` for “${debouncedSearchTerm}”` : ""}`}
         </Text>
       )}
+
+      {showInlineSpinner && (
+        <View style={styles.inlineSpinner}>
+          <ActivityIndicator size="small" color="#CA251B" />
+          <Text style={styles.inlineSpinnerText}>Updating results...</Text>
+        </View>
+      )}
+
       <View style={styles.cardList}>
-        {filteredResults.map((item) => (
-          <RestaurantCard key={item.id} data={item} />
-        ))}
+        {isLoading ? (
+          <View style={styles.stateContainer}>
+            <ActivityIndicator size="large" color="#CA251B" />
+            <Text style={styles.stateText}>Loading restaurants...</Text>
+          </View>
+        ) : isError ? (
+          <View style={styles.stateContainer}>
+            <Text style={styles.stateText}>We couldn't load restaurants. Please try again.</Text>
+            <TouchableOpacity style={styles.retryButton} activeOpacity={0.8} onPress={() => refetch()}>
+              <Text style={styles.retryText}>Retry</Text>
+            </TouchableOpacity>
+          </View>
+        ) : isEmpty ? (
+          <View style={styles.stateContainer}>
+            <Text style={styles.stateText}>No restaurants match your filters yet.</Text>
+          </View>
+        ) : (
+          restaurants.map((item) => <RestaurantCard key={item.id} data={item} />)
+        )}
       </View>
     </View>
   );
 
   return (
     <>
-    <MainLayout
-      headerBackgroundImage={require("../../assets/pattern1.png")}
-      showHeader
-      showFooter
-      activeTab="Search"
-      headerMaxHeight={vs(160)}
-      headerMinHeight={vs(120)}
-      customHeader={customHeader}
-      enableHeaderCollapse={false}
-      mainContent={mainContent}
-    />
-    <FiltersOverlay
-  visible={showFilters}
-  onClose={() => setShowFilters(false)}
-  onClearAll={() => {
-    setFilters({
-      filter: false,
-      promotions: false,
-      topChoice: false,
-      freeDelivery: false,
-    });
-  }}
-/>
-</>
+      <MainLayout
+        headerBackgroundImage={require("../../assets/pattern1.png")}
+        showHeader
+        showFooter
+        activeTab="Search"
+        headerMaxHeight={vs(160)}
+        headerMinHeight={vs(120)}
+        customHeader={customHeader}
+        enableHeaderCollapse={false}
+        mainContent={mainContent}
+      />
+      <FiltersOverlay
+        visible={showFilters}
+        onClose={() => setShowFilters(false)}
+        onApply={handleApplyOverlayFilters}
+        onClearAll={handleClearAll}
+        initialFilters={overlayFilters}
+      />
+    </>
   );
 }
 
@@ -265,7 +336,7 @@ const styles = ScaledSheet.create({
   pillButton: {
     flexDirection: "row",
     alignItems: "center",
-    backgroundColor: "white", 
+    backgroundColor: "white",
     borderRadius: "20@ms",
     paddingHorizontal: "14@s",
     paddingVertical: "8@vs",
@@ -273,7 +344,7 @@ const styles = ScaledSheet.create({
     borderColor: "#CA251B",
   },
   pillActive: {
-    backgroundColor: "#CA251B", 
+    backgroundColor: "#CA251B",
     borderColor: "white",
   },
   pillText: {
@@ -304,6 +375,19 @@ const styles = ScaledSheet.create({
     marginBottom: "12@vs",
     color: "#8B909D",
     textAlign: "center",
+  },
+  inlineSpinner: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: "8@s",
+    marginBottom: "12@vs",
+  },
+  inlineSpinnerText: {
+    color: "#8B909D",
+    fontFamily: "Roboto",
+    fontSize: "13@ms",
+    fontWeight: "500",
   },
   cardList: { gap: "16@vs" },
   card: {
@@ -385,6 +469,32 @@ const styles = ScaledSheet.create({
     color: "white",
     fontFamily: "Roboto",
     fontSize: "13@ms",
+    fontWeight: "600",
+  },
+  stateContainer: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: "40@vs",
+    gap: "16@vs",
+  },
+  stateText: {
+    textAlign: "center",
+    color: "#6B7280",
+    fontFamily: "Roboto",
+    fontSize: "14@ms",
+    fontWeight: "500",
+    maxWidth: "240@s",
+  },
+  retryButton: {
+    backgroundColor: "#CA251B",
+    borderRadius: "24@ms",
+    paddingHorizontal: "24@s",
+    paddingVertical: "10@vs",
+  },
+  retryText: {
+    color: "white",
+    fontFamily: "Roboto",
+    fontSize: "14@ms",
     fontWeight: "600",
   },
 });

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -33,6 +33,7 @@ import type {
 } from "~/interfaces/Restaurant";
 import { useCart } from "~/context/CartContext";
 import type { CartItemOptionSelection } from "~/context/CartContext";
+import { getMenuItemBasePrice } from "~/utils/menuPricing";
 
 const FALLBACK_IMAGE = require("../../assets/TEST.png");
 const FALLBACK_MENU_IMAGE = require("../../assets/TEST.png");
@@ -377,7 +378,7 @@ export default function SearchScreen() {
             name: selectedMenuItem.name,
             description: selectedMenuItem.description,
             imageUrl: selectedMenuItem.imageUrl,
-            price: selectedMenuItem.price,
+            price: getMenuItemBasePrice(selectedMenuItem),
           },
           quantity: item.quantity,
           extras: item.extras,

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -34,6 +34,7 @@ import type {
 import { useCart } from "~/context/CartContext";
 import type { CartItemOptionSelection } from "~/context/CartContext";
 import { getMenuItemBasePrice } from "~/utils/menuPricing";
+import { BASE_API_URL } from "@env";
 
 const FALLBACK_IMAGE = require("../../assets/TEST.png");
 const FALLBACK_MENU_IMAGE = require("../../assets/TEST.png");
@@ -120,7 +121,7 @@ const RestaurantCard = ({
 }) => {
   const { name, deliveryTimeRange, rating, isTopChoice, hasFreeDelivery, imageUrl } = data;
 
-  const imageSource = imageUrl ? { uri: imageUrl } : FALLBACK_IMAGE;
+  const imageSource = imageUrl ? { uri: `${BASE_API_URL}/auth/image/${imageUrl}` } : FALLBACK_IMAGE;
   const formattedRating = Number.isFinite(rating) ? `${rating}/5` : "-";
 
   return (
@@ -165,7 +166,7 @@ const PromotedMenuItemCard = ({
   onPress: () => void;
 }) => {
   const { name, promotionLabel, price, promotionPrice, imageUrl } = item;
-  const imageSource = imageUrl ? { uri: imageUrl } : FALLBACK_MENU_IMAGE;
+  const imageSource = imageUrl ? { uri: `${BASE_API_URL}/auth/image/${imageUrl}` } : FALLBACK_MENU_IMAGE;
   const hasPromoPrice = typeof promotionPrice === "number" && Number.isFinite(promotionPrice);
 
   return (

--- a/src/utils/menuPricing.ts
+++ b/src/utils/menuPricing.ts
@@ -1,0 +1,40 @@
+export type PromotionAwareMenuItem = {
+  price: number;
+  promotionActive?: boolean | null;
+  promotionPrice?: number | null;
+  promotionLabel?: string | null;
+};
+
+export const hasActivePromotion = (
+  item?: PromotionAwareMenuItem | null
+): item is PromotionAwareMenuItem & { promotionPrice: number } => {
+  if (!item) {
+    return false;
+  }
+
+  if (!item.promotionActive) {
+    return false;
+  }
+
+  if (typeof item.promotionPrice !== 'number') {
+    return false;
+  }
+
+  if (!Number.isFinite(item.promotionPrice)) {
+    return false;
+  }
+
+  if (item.promotionPrice >= item.price) {
+    return false;
+  }
+
+  return true;
+};
+
+export const getMenuItemBasePrice = (item: PromotionAwareMenuItem): number => {
+  if (hasActivePromotion(item)) {
+    return item.promotionPrice;
+  }
+
+  return item.price;
+};


### PR DESCRIPTION
## Summary
- replace the mock search data with the real /client/restaurants/search backend endpoint and wire search, filter, and sort params
- add loading, empty, and error feedback for the search results plus inline refresh indicators while background refetches run
- share a debounce hook, propagate applied filter state through FiltersOverlay, and extend restaurant interfaces with search response types
- align the search request payload with the backend’s expected query parameters and default filter state

## Testing
- npm run lint *(fails: Cannot find module 'eslint/config')*

------
https://chatgpt.com/codex/tasks/task_b_68e26a882d68832cb796418cfb011e98