### PR TITLE
feat: show ongoing order banner in footer

### DIFF
--- a/src/api/orders.ts
+++ b/src/api/orders.ts
@@ -1,5 +1,5 @@
 import client from './client';
-import type { CreateOrderResponse, OrderDto, OrderRequest } from '~/interfaces/Order';
+import type { CreateOrderResponse, OrderDto, OrderNotificationDto, OrderRequest } from '~/interfaces/Order';
 
 export const createOrder = async (payload: OrderRequest) => {
   const { data } = await client.post<CreateOrderResponse>('/orders/create', payload);
@@ -9,6 +9,20 @@ export const createOrder = async (payload: OrderRequest) => {
 export const getMyOrders = async () => {
   const { data } = await client.get<OrderDto[]>('/client/my-orders');
   return data ?? [];
+};
+
+export const getOngoingOrder = async () => {
+  const response = await client.get<OrderNotificationDto | null>('/orders/ongoing');
+  if (response.status === 204) {
+    return null;
+  }
+
+  const payload = response.data;
+  if (payload == null || payload === '') {
+    return null;
+  }
+
+  return payload;
 };
 
 export type { CreateOrderResponse, OrderRequest, OrderDto };

--- a/src/hooks/useOngoingOrder.ts
+++ b/src/hooks/useOngoingOrder.ts
@@ -1,0 +1,119 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { getOngoingOrder } from '~/api/orders';
+import useAuth from '~/hooks/useAuth';
+import { useWebSocketContext } from '~/context/WebSocketContext';
+import type { OrderNotificationDto } from '~/interfaces/Order';
+import { mergeOrderLikeData } from '~/utils/order';
+
+const TERMINAL_STATUSES = new Set(['DELIVERED', 'CANCELED', 'REJECTED']);
+
+export type OngoingOrderData = Partial<OrderNotificationDto> & {
+  orderId?: number | string | null;
+};
+
+const normalizeStatus = (status: unknown) => {
+  if (!status) {
+    return null;
+  }
+
+  return String(status).toUpperCase();
+};
+
+const resolveLatestStatus = (order: OngoingOrderData | null) => {
+  if (!order) {
+    return null;
+  }
+
+  if (order.statusHistory?.length) {
+    const lastEntry = order.statusHistory[order.statusHistory.length - 1];
+    if (lastEntry?.newStatus) {
+      return normalizeStatus(lastEntry.newStatus);
+    }
+  }
+
+  return normalizeStatus(order.status);
+};
+
+export default function useOngoingOrder() {
+  const { requiresAuth } = useAuth();
+  const { latestOrderUpdate, orderUpdates } = useWebSocketContext();
+
+  const queryResult = useQuery<OngoingOrderData | null>({
+    queryKey: ['orders', 'ongoing'],
+    queryFn: async () => {
+      const data = await getOngoingOrder();
+      return data ?? null;
+    },
+    enabled: requiresAuth,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: Number.POSITIVE_INFINITY,
+    retry: 1,
+  });
+
+  const baseOrder = (requiresAuth ? queryResult.data : null) as OngoingOrderData | null;
+
+  const websocketOrder = useMemo(() => {
+    if (!requiresAuth) {
+      return null;
+    }
+
+    const baseOrderId = baseOrder?.orderId ?? null;
+
+    if (baseOrderId != null) {
+      const keyedUpdate = orderUpdates[String(baseOrderId)];
+      if (keyedUpdate) {
+        return keyedUpdate as OngoingOrderData;
+      }
+    }
+
+    if (latestOrderUpdate?.orderId != null) {
+      if (!baseOrderId || latestOrderUpdate.orderId === baseOrderId) {
+        return latestOrderUpdate as OngoingOrderData;
+      }
+
+      const keyedUpdate = orderUpdates[String(latestOrderUpdate.orderId)];
+      if (keyedUpdate) {
+        return keyedUpdate as OngoingOrderData;
+      }
+    }
+
+    if (!baseOrderId) {
+      const firstKey = Object.keys(orderUpdates).find((key) => orderUpdates[key]);
+      if (firstKey) {
+        return orderUpdates[firstKey] as OngoingOrderData;
+      }
+    }
+
+    return null;
+  }, [baseOrder?.orderId, latestOrderUpdate, orderUpdates, requiresAuth]);
+
+  const mergedOrder = useMemo(() => {
+    if (!requiresAuth) {
+      return null;
+    }
+
+    return mergeOrderLikeData<OngoingOrderData>(baseOrder, websocketOrder);
+  }, [baseOrder, requiresAuth, websocketOrder]);
+
+  const resolvedOrderId =
+    mergedOrder?.orderId ?? websocketOrder?.orderId ?? baseOrder?.orderId ?? null;
+
+  const terminalStatus = resolveLatestStatus(mergedOrder);
+  const isTerminal = terminalStatus ? TERMINAL_STATUSES.has(terminalStatus) : false;
+
+  const order =
+    requiresAuth && mergedOrder && !isTerminal
+      ? ({ ...mergedOrder, orderId: resolvedOrderId } as OngoingOrderData)
+      : null;
+
+  return {
+    order,
+    isLoading: requiresAuth ? queryResult.isLoading : false,
+    isFetching: requiresAuth ? queryResult.isFetching : false,
+    refetch: queryResult.refetch,
+    error: queryResult.error,
+    hasFetched: requiresAuth ? queryResult.isFetched : false,
+  };
+}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,6 +1,6 @@
-import { Home, Search, ShoppingBag, User } from 'lucide-react-native';
+import { ChevronDown, ChevronUp, Home, Search, ShoppingBag, User } from 'lucide-react-native';
 import type { LucideIcon } from 'lucide-react-native';
-import { ReactNode, useCallback, useEffect, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   View,
   TouchableOpacity,
@@ -8,7 +8,6 @@ import {
   ImageBackground,
   StyleSheet,
   Dimensions,
-  Platform,
   RefreshControl,
 } from 'react-native';
 import Animated, {
@@ -24,8 +23,9 @@ import Animated, {
 } from 'react-native-reanimated';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, NavigationProp } from '@react-navigation/native';
-import { ScaledSheet, s, vs, ms } from 'react-native-size-matters';
-import { Image } from 'expo-image';
+import { ScaledSheet, s, vs } from 'react-native-size-matters';
+import useOngoingOrder from '~/hooks/useOngoingOrder';
+import { formatOrderStatusLabel } from '~/utils/order';
 
 type NavItem = {
   icon: LucideIcon;
@@ -43,7 +43,7 @@ const defaultNavItems: NavItem[] = [
 const useOptionalNavigation = () => {
   try {
     return useNavigation<NavigationProp<Record<string, object | undefined>>>();
-  } catch (error) {
+  } catch (_error) {
     return undefined;
   }
 };
@@ -51,7 +51,7 @@ const useOptionalNavigation = () => {
 const useOptionalRoute = () => {
   try {
     return useRoute();
-  } catch (error) {
+  } catch (_error) {
     return undefined;
   }
 };
@@ -119,6 +119,8 @@ export default function MainLayout({
 
   const navigation = useOptionalNavigation();
   const route = useOptionalRoute();
+  const { order: ongoingOrder } = useOngoingOrder();
+  const [isOngoingExpanded, setIsOngoingExpanded] = useState(false);
   const scrollY = useSharedValue(0);
   const [activeHeader, setActiveHeader] = useState<'full' | 'collapsed'>(
     collapseEnabled && headerCollapsed ? 'collapsed' : 'full'
@@ -138,6 +140,12 @@ export default function MainLayout({
     }
     setActiveHeader(headerCollapsed ? 'collapsed' : 'full');
   }, [collapseEnabled, headerCollapsed]);
+
+  useEffect(() => {
+    if (!ongoingOrder) {
+      setIsOngoingExpanded(false);
+    }
+  }, [ongoingOrder]);
 
   const updateActiveHeader = useCallback((next: 'full' | 'collapsed') => {
     setActiveHeader((previous) => (previous === next ? previous : next));
@@ -278,6 +286,57 @@ export default function MainLayout({
   const routeName = route?.name;
   const resolvedActiveTab = activeTab ?? (routeName && resolvedNavItems.find((item) => item.route === routeName) ? routeName : undefined);
 
+  const defaultFooterHeight = vs(80);
+  const collapsedOngoingHeight = vs(120);
+  const expandedOngoingHeight = vs(160);
+  const resolvedFooterHeight = !showFooter
+    ? 0
+    : ongoingOrder
+    ? isOngoingExpanded
+      ? expandedOngoingHeight
+      : collapsedOngoingHeight
+    : defaultFooterHeight;
+  const fallbackContentPadding = vs(20);
+  const floatingBottomOffset = showFooter
+    ? insets.bottom + resolvedFooterHeight + vs(4)
+    : insets.bottom + vs(24);
+
+  const ongoingStatusLabel = useMemo(() => {
+    if (!ongoingOrder) {
+      return null;
+    }
+
+    const history = ongoingOrder.statusHistory ?? [];
+    if (history.length) {
+      const lastEntry = history[history.length - 1];
+      const label = formatOrderStatusLabel(lastEntry?.newStatus ?? null);
+      if (label) {
+        return label;
+      }
+    }
+
+    return formatOrderStatusLabel(ongoingOrder.status ?? null);
+  }, [ongoingOrder]);
+
+  const handleToggleOngoing = useCallback(() => {
+    setIsOngoingExpanded((previous) => !previous);
+  }, []);
+
+  const handleViewOrderDetails = useCallback(() => {
+    if (!ongoingOrder) {
+      return;
+    }
+
+    const params = {
+      order: ongoingOrder as any,
+      orderId: ongoingOrder.orderId ?? null,
+    };
+
+    if (navigation) {
+      navigation.navigate('OrderTracking' as never, params as never);
+    }
+  }, [navigation, ongoingOrder]);
+
   const headerNode = !showHeader
     ? null
     : collapseEnabled
@@ -300,7 +359,7 @@ export default function MainLayout({
         style={[styles.scrollView]}
         contentContainerStyle={{
           paddingTop: collapseEnabled ? vs(10) : vs(20),
-          paddingBottom: showFooter ? vs(80) : vs(20),
+          paddingBottom: showFooter ? resolvedFooterHeight : fallbackContentPadding,
         }}
         refreshControl={refreshControl}
         scrollEventThrottle={16}
@@ -312,7 +371,7 @@ export default function MainLayout({
         <View
           style={[
             styles.floatingSlot,
-            { bottom: showFooter ? insets.bottom + vs(84) : insets.bottom + vs(24) },
+            { bottom: floatingBottomOffset },
           ]}
           pointerEvents="box-none">
           {floatingContent}
@@ -320,8 +379,16 @@ export default function MainLayout({
       ) : null}
 
       {showFooter && (
-        <View style={[styles.footer, { paddingBottom: insets.bottom }]}>
-          <View style={styles.navRow}>
+        <View style={[styles.footer, { paddingBottom: insets.bottom + vs(10) }]}>
+          {ongoingOrder ? (
+            <OngoingOrderSection
+              isExpanded={isOngoingExpanded}
+              onToggle={handleToggleOngoing}
+              statusLabel={ongoingStatusLabel ?? 'Tracking...'}
+              onPressDetails={handleViewOrderDetails}
+            />
+          ) : null}
+          <View style={[styles.navRow, ongoingOrder ? styles.navRowWithBanner : null]}>
             {resolvedNavItems.map((item) => {
               const Icon = item.icon;
               const isActive = resolvedActiveTab === item.route;
@@ -351,6 +418,60 @@ export default function MainLayout({
     </SafeAreaView>
   );
 }
+
+interface OngoingOrderSectionProps {
+  isExpanded: boolean;
+  onToggle: () => void;
+  statusLabel: string;
+  onPressDetails: () => void;
+}
+
+const OngoingOrderSection = ({
+  isExpanded,
+  onToggle,
+  statusLabel,
+  onPressDetails,
+}: OngoingOrderSectionProps) => {
+  return (
+    <View style={styles.ongoingContainer}>
+      <TouchableOpacity
+        activeOpacity={0.85}
+        onPress={onToggle}
+        style={styles.ongoingHeader}
+      >
+        <Text allowFontScaling={false} style={styles.ongoingHeaderText} numberOfLines={1}>
+          your order is on the way
+        </Text>
+        {isExpanded ? (
+          <ChevronDown size={s(18)} color="#FFFFFF" />
+        ) : (
+          <ChevronUp size={s(18)} color="#FFFFFF" />
+        )}
+      </TouchableOpacity>
+      {isExpanded ? (
+        <View style={styles.ongoingBody}>
+          <View style={styles.statusCard}>
+            <Text allowFontScaling={false} style={styles.statusCardLabel}>
+              Status
+            </Text>
+            <Text allowFontScaling={false} style={styles.statusCardValue} numberOfLines={2}>
+              {statusLabel}
+            </Text>
+          </View>
+          <TouchableOpacity
+            activeOpacity={0.85}
+            style={styles.detailsButton}
+            onPress={onPressDetails}
+          >
+            <Text allowFontScaling={false} style={styles.detailsButtonLabel}>
+              See Details
+            </Text>
+          </TouchableOpacity>
+        </View>
+      ) : null}
+    </View>
+  );
+};
 
 const styles = ScaledSheet.create({
   container: { flex: 1, backgroundColor: 'white' },
@@ -398,10 +519,71 @@ const styles = ScaledSheet.create({
     borderTopRightRadius: '24@ms',
     zIndex: 2,
   },
+  ongoingContainer: {
+    width: '100%',
+    borderRadius: '18@ms',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#243255',
+    paddingVertical: '12@vs',
+    paddingHorizontal: '18@s',
+    backgroundColor: 'rgba(255, 255, 255, 0.04)',
+    marginBottom: '12@vs',
+  },
+  ongoingHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  ongoingHeaderText: {
+    color: '#FFFFFF',
+    fontSize: '14@ms',
+    fontWeight: '600',
+  },
+  ongoingBody: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    marginTop: '12@vs',
+  },
+  statusCard: {
+    flex: 1,
+    backgroundColor: '#CA251B',
+    borderRadius: '16@ms',
+    paddingVertical: '12@vs',
+    paddingHorizontal: '14@s',
+    marginRight: '12@s',
+  },
+  statusCardLabel: {
+    color: '#FFFFFF',
+    fontSize: '13@ms',
+    fontWeight: '700',
+  },
+  statusCardValue: {
+    color: '#FFFFFF',
+    fontSize: '12@ms',
+    marginTop: '4@vs',
+    fontWeight: '500',
+  },
+  detailsButton: {
+    flex: 1,
+    backgroundColor: '#CA251B',
+    borderRadius: '16@ms',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: '14@vs',
+    paddingHorizontal: '12@s',
+  },
+  detailsButtonLabel: {
+    color: '#FFFFFF',
+    fontSize: '14@ms',
+    fontWeight: '700',
+  },
   navRow: {
     flexDirection: 'row',
     justifyContent: 'space-around',
     alignItems: 'center',
+  },
+  navRowWithBanner: {
+    marginTop: '16@vs',
   },
   navButton: {
     alignItems: 'center',

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -1,0 +1,87 @@
+import type {
+  CreateOrderResponse,
+  OrderNotificationDto,
+  OrderStatusHistoryDto,
+} from '~/interfaces/Order';
+
+export type OrderLike = Partial<CreateOrderResponse> &
+  Partial<OrderNotificationDto> & {
+    orderId?: number | string | null;
+    statusHistory?: OrderStatusHistoryDto[] | null | undefined;
+    [key: string]: unknown;
+  };
+
+export const formatOrderStatusLabel = (status: string | null | undefined) => {
+  if (!status) {
+    return null;
+  }
+
+  return status
+    .toString()
+    .toLowerCase()
+    .split('_')
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+};
+
+export const mergeOrderLikeData = <T extends OrderLike>(
+  baseOrder: T | null | undefined,
+  update: Partial<T> | null | undefined,
+): T | null => {
+  if (!baseOrder && !update) {
+    return null;
+  }
+
+  const base = (baseOrder ?? {}) as OrderLike;
+  const overlay = (update ?? {}) as OrderLike;
+
+  const mergedRestaurant =
+    base.restaurant || overlay.restaurant
+      ? {
+          ...((base.restaurant as Record<string, unknown>) ?? {}),
+          ...((overlay.restaurant as Record<string, unknown>) ?? {}),
+        }
+      : undefined;
+
+  const mergedDeliveryBase: Record<string, unknown> = {
+    ...((base.delivery as Record<string, unknown>) ?? {}),
+    ...((overlay.delivery as Record<string, unknown>) ?? {}),
+  };
+
+  const baseDeliveryDriver = (base as any)?.delivery?.driver;
+  const overlayDeliveryDriver = (overlay as any)?.delivery?.driver;
+
+  if (baseDeliveryDriver != null || overlayDeliveryDriver != null) {
+    mergedDeliveryBase.driver = {
+      ...((baseDeliveryDriver as Record<string, unknown>) ?? {}),
+      ...((overlayDeliveryDriver as Record<string, unknown>) ?? {}),
+    };
+  }
+
+  const mergedPayment =
+    base.payment || overlay.payment
+      ? {
+          ...((base.payment as Record<string, unknown>) ?? {}),
+          ...((overlay.payment as Record<string, unknown>) ?? {}),
+        }
+      : undefined;
+
+  const merged: OrderLike = {
+    ...base,
+    ...overlay,
+    ...(mergedRestaurant ? { restaurant: mergedRestaurant } : {}),
+    ...(Object.keys(mergedDeliveryBase).length ? { delivery: mergedDeliveryBase } : {}),
+    ...(mergedPayment ? { payment: mergedPayment } : {}),
+    items: overlay.items ?? base.items,
+    workflow: overlay.workflow ?? base.workflow,
+    statusHistory: overlay.statusHistory ?? base.statusHistory,
+    status: overlay.status ?? base.status,
+    orderId: overlay.orderId ?? base.orderId,
+  };
+
+  if (merged.orderId == null && baseOrder?.orderId != null) {
+    merged.orderId = baseOrder.orderId;
+  }
+
+  return merged as T;
+};


### PR DESCRIPTION
## Summary
- add an API helper and hook to fetch a single ongoing order and merge websocket updates
- extract reusable order utilities for status formatting and deep merge logic
- surface an expandable ongoing-order banner above the tab bar and reuse the utilities in order tracking

## Testing
- npm run lint *(fails: repository already reports missing @env modules and other pre-existing lint violations)*

------
https://chatgpt.com/codex/tasks/task_b_68e2d6130550832cbeffc1ff5dfb00f1